### PR TITLE
Add baseline hours tracking to monthly phase summary

### DIFF
--- a/src/components/wbs/monthly-phase-summary.tsx
+++ b/src/components/wbs/monthly-phase-summary.tsx
@@ -41,6 +41,7 @@ type Cell = {
   plannedHours: number;
   actualHours: number;
   difference: number;
+  baselineHours: number;
   forecastHours: number;
 };
 
@@ -81,6 +82,7 @@ export function MonthlyPhaseSummary({
           plannedHours: entry.plannedHours,
           actualHours: entry.actualHours,
           difference: entry.difference,
+          baselineHours: entry.baselineHours || 0,
           forecastHours: entry.forecastHours || 0,
         });
       }
@@ -117,6 +119,7 @@ export function MonthlyPhaseSummary({
         plannedHours: monthlyData.grandTotal.plannedHours,
         actualHours: monthlyData.grandTotal.actualHours,
         difference: monthlyData.grandTotal.difference,
+        baselineHours: monthlyData.grandTotal.baselineHours,
         forecastHours: monthlyData.grandTotal.forecastHours,
       };
 
@@ -315,13 +318,14 @@ export function MonthlyPhaseSummary({
                 plannedHours: 0,
                 actualHours: 0,
                 difference: 0,
+                baselineHours: 0,
                 forecastHours: 0,
               };
               return {
                 plannedHours: cell.plannedHours,
                 actualHours: cell.actualHours,
                 difference: cell.difference,
-                baselineHours: 0,
+                baselineHours: cell.baselineHours,
                 forecastHours: cell.forecastHours,
               } as SummaryCell;
             }}


### PR DESCRIPTION
## Summary
This PR adds support for tracking and displaying baseline hours in the monthly phase summary component. The baseline hours are now properly propagated through the data model and included in the summary cell calculations.

## Key Changes
- Added `baselineHours` field to the `Cell` type definition
- Updated cell creation logic to include `baselineHours` from entry data (with fallback to 0)
- Updated grand total cell creation to include `baselineHours` from monthly data
- Fixed baseline hours initialization in the summary cell mapping to use the actual cell value instead of hardcoded 0

## Implementation Details
- The `baselineHours` field is now consistently populated across all cell types (regular entries, grand totals, and summary cells)
- Maintains backward compatibility by using a fallback value of 0 when `baselineHours` is not provided in the source data
- The summary cell mapping now correctly preserves the `baselineHours` value from the cell object rather than overwriting it with 0

https://claude.ai/code/session_0119MyxkgqXd6R8CoBrmqf2t