### PR TITLE
Enable actual results fields and improve table cell rendering

### DIFF
--- a/src/components/wbs/task-table-view.tsx
+++ b/src/components/wbs/task-table-view.tsx
@@ -411,9 +411,9 @@ export function TaskTableViewPage({
             yoteiStart: wbsTask.yoteiStart,
             yoteiEnd: wbsTask.yoteiEnd,
             yoteiKosu: wbsTask.yoteiKosu,
-            // jissekiStart: wbsTask.jissekiStart,
-            // jissekiEnd: wbsTask.jissekiEnd,
-            // jissekiKosu: wbsTask.jissekiKosu,
+            jissekiStart: wbsTask.jissekiStart,
+            jissekiEnd: wbsTask.jissekiEnd,
+            jissekiKosu: wbsTask.jissekiKosu,
             status: wbsTask.status,
             assigneeId: String(wbsTask.assigneeId ?? ""),
             assignee: wbsTask.assignee?.displayName ?? "未設定",
@@ -555,10 +555,18 @@ export function TaskTableViewPage({
                     >
                       {row.getVisibleCells().map((cell) => (
                         <TableCell key={cell.id}>
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext(),
-                          )}
+                          {cell.getIsPlaceholder()
+                            ? null
+                            : cell.getIsAggregated()
+                              ? flexRender(
+                                  cell.column.columnDef.aggregatedCell ??
+                                    cell.column.columnDef.cell,
+                                  cell.getContext(),
+                                )
+                              : flexRender(
+                                  cell.column.columnDef.cell,
+                                  cell.getContext(),
+                                )}
                         </TableCell>
                       ))}
                     </TableRow>


### PR DESCRIPTION
## Summary
This PR enables the actual results (jisseki) fields in the task table and improves the table cell rendering logic to properly handle aggregated cells and placeholders.

## Key Changes
- **Uncommented jisseki fields**: Enabled `jissekiStart`, `jissekiEnd`, and `jissekiKosu` fields in the task data mapping, allowing actual results data to be displayed in the table
- **Enhanced cell rendering logic**: Updated the table cell rendering to:
  - Skip rendering for placeholder cells
  - Use `aggregatedCell` column definition when a cell is aggregated, falling back to the standard `cell` definition
  - Maintain backward compatibility with non-aggregated cells

## Implementation Details
The cell rendering now follows a conditional hierarchy:
1. Returns `null` for placeholder cells (no content to render)
2. For aggregated cells, uses the `aggregatedCell` column definition if available, otherwise falls back to the standard `cell` definition
3. For regular cells, renders using the standard `cell` definition

This allows the table to properly display aggregated data (such as totals or summaries) when grouping is applied, while maintaining normal rendering for individual rows.

https://claude.ai/code/session_01Sa94wdMk4seBWQ1eofk1WM