### PR TITLE
Refactor monthly summary table to display differences inline

### DIFF
--- a/src/components/wbs/monthly-assignee-summary.tsx
+++ b/src/components/wbs/monthly-assignee-summary.tsx
@@ -320,6 +320,8 @@ export function MonthlyAssigneeSummary({
                     difference: monthlyData.assigneeTotals[a].difference,
                     baselineHours:
                       monthlyData.assigneeTotals[a].baselineHours || 0,
+                    forecastHours:
+                      monthlyData.assigneeTotals[a].forecastHours || 0,
                   },
                 ])
               )}

--- a/src/components/wbs/monthly-phase-summary.tsx
+++ b/src/components/wbs/monthly-phase-summary.tsx
@@ -96,6 +96,7 @@ export function MonthlyPhaseSummary({
             plannedHours: monthlyData.monthlyTotals[m]?.plannedHours || 0,
             actualHours: monthlyData.monthlyTotals[m]?.actualHours || 0,
             difference: monthlyData.monthlyTotals[m]?.difference || 0,
+            baselineHours: monthlyData.monthlyTotals[m]?.baselineHours || 0,
             forecastHours: monthlyData.monthlyTotals[m]?.forecastHours || 0,
           },
         ])
@@ -109,6 +110,7 @@ export function MonthlyPhaseSummary({
             plannedHours: monthlyData.phaseTotals[p.key]?.plannedHours || 0,
             actualHours: monthlyData.phaseTotals[p.key]?.actualHours || 0,
             difference: monthlyData.phaseTotals[p.key]?.difference || 0,
+            baselineHours: monthlyData.phaseTotals[p.key]?.baselineHours || 0,
             forecastHours: monthlyData.phaseTotals[p.key]?.forecastHours || 0,
           },
         ])

--- a/src/components/wbs/monthly-summary-table.tsx
+++ b/src/components/wbs/monthly-summary-table.tsx
@@ -71,13 +71,24 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
         });
     };
 
+    const formatSignedDifference = (diff: number) => {
+        const converted = convertHours(diff, hoursUnit);
+        const abs = Math.abs(converted).toLocaleString("ja-JP", {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        });
+        if (converted > 0) return `+${abs}`;
+        if (converted < 0) return `-${abs}`;
+        return `±${abs}`;
+    };
+
     const getDifferenceColor = (difference: number) => {
         if (difference > 0) return "text-red-600"; // 実績が予定超過
         if (difference === 0) return "text-green-600"; // 完全一致
         return "text-blue-600"; // 実績が予定未達
     };
 
-    const monthColSpan = (showBaseline ? 1 : 0) + 2 + (showDifference ? 1 : 0) + (showForecast ? 1 : 0);
+    const monthColSpan = (showBaseline ? 1 : 0) + 2 /* 予定 + 実績 */ + (showForecast ? 1 : 0);
 
     // スタイル：先頭列固定幅
     const firstColStyle = (() => {
@@ -113,7 +124,7 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                             {m}
                         </TableHead>
                     ))}
-                    <TableHead className="text-center font-semibold min-w-[200px]" colSpan={3}>
+                    <TableHead className="text-center font-semibold min-w-[200px]" colSpan={monthColSpan}>
                         合計
                     </TableHead>
                 </TableRow>
@@ -129,22 +140,30 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                             )}
                             <TableHead className="text-center text-xs min-w-[60px]">予定({getUnitSuffix(hoursUnit)})</TableHead>
                             <TableHead
-                                className={`text-center text-xs min-w-[60px] ${!showDifference && !showForecast ? "border-r" : ""}`}
+                                className={`text-center text-xs min-w-[60px] ${!showForecast ? "border-r" : ""}`}
                             >
-                                実績({getUnitSuffix(hoursUnit)})
+                                {showDifference ? `実績(差分)(${getUnitSuffix(hoursUnit)})` : `実績(${getUnitSuffix(hoursUnit)})`}
                             </TableHead>
-                            {showDifference && (
-                                <TableHead className={`text-center text-xs min-w-[60px] ${!showForecast ? "border-r" : ""}`}>差分</TableHead>
-                            )}
                             {showForecast && (
-                                <TableHead className="text-center text-xs min-w-[60px] border-r">見通({getUnitSuffix(hoursUnit)})</TableHead>
+                                <TableHead className="text-center text-xs min-w-[60px] border-r">
+                                    {showDifference ? `見通(差分)(${getUnitSuffix(hoursUnit)})` : `見通(${getUnitSuffix(hoursUnit)})`}
+                                </TableHead>
                             )}
                         </React.Fragment>
                     ))}
                     <React.Fragment key="grand">
+                        {showBaseline && (
+                            <TableHead className="text-center text-xs min-w-[60px]">基準({getUnitSuffix(hoursUnit)})</TableHead>
+                        )}
                         <TableHead className="text-center text-xs min-w-[60px]">予定({getUnitSuffix(hoursUnit)})</TableHead>
-                        <TableHead className="text-center text-xs min-w-[60px]">実績({getUnitSuffix(hoursUnit)})</TableHead>
-                        <TableHead className="text-center text-xs min-w-[60px]">差分</TableHead>
+                        <TableHead className="text-center text-xs min-w-[60px]">
+                            {showDifference ? `実績(差分)(${getUnitSuffix(hoursUnit)})` : `実績(${getUnitSuffix(hoursUnit)})`}
+                        </TableHead>
+                        {showForecast && (
+                            <TableHead className="text-center text-xs min-w-[60px]">
+                                {showDifference ? `見通(差分)(${getUnitSuffix(hoursUnit)})` : `見通(${getUnitSuffix(hoursUnit)})`}
+                            </TableHead>
+                        )}
                     </React.Fragment>
                 </TableRow>
             </TableHeader>
@@ -177,6 +196,7 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                                 const diff = cell?.difference || 0;
                                 const baseline = cell?.baselineHours || 0;
                                 const forecast = cell?.forecastHours || 0;
+                                const forecastDiff = forecast - planned;
                                 return (
                                     <React.Fragment key={m}>
                                         {showBaseline && (
@@ -188,36 +208,72 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                                             {planned > 0 ? formatNumber(planned) : "-"}
                                         </TableCell>
                                         <TableCell
-                                            className={`text-center text-sm min-w-[60px] ${!showDifference && !showForecast ? "border-r" : ""}`}
+                                            className={`text-center text-sm min-w-[60px] ${!showForecast ? "border-r" : ""}`}
                                         >
-                                            {actual > 0 ? formatNumber(actual) : "-"}
+                                            {planned > 0 || actual > 0 ? (
+                                                <>
+                                                    {formatNumber(actual)}
+                                                    {showDifference && (
+                                                        <span className={`ml-1 ${getDifferenceColor(diff)}`}>
+                                                            ({formatSignedDifference(diff)})
+                                                        </span>
+                                                    )}
+                                                </>
+                                            ) : (
+                                                "-"
+                                            )}
                                         </TableCell>
-                                        {showDifference && (
-                                            <TableCell
-                                                className={`text-center text-sm min-w-[60px] ${getDifferenceColor(diff)} ${!showForecast ? "border-r" : ""}`}
-                                            >
-                                                {planned > 0 || actual > 0 ? formatNumber(diff) : "-"}
-                                            </TableCell>
-                                        )}
                                         {showForecast && (
                                             <TableCell className="text-center text-sm min-w-[60px] border-r">
-                                                {forecast > 0 ? formatNumber(forecast) : "-"}
+                                                {forecast > 0 ? (
+                                                    <>
+                                                        {formatNumber(forecast)}
+                                                        {showDifference && (
+                                                            <span className={`ml-1 ${getDifferenceColor(forecastDiff)}`}>
+                                                                ({formatSignedDifference(forecastDiff)})
+                                                            </span>
+                                                        )}
+                                                    </>
+                                                ) : (
+                                                    "-"
+                                                )}
                                             </TableCell>
                                         )}
                                     </React.Fragment>
                                 );
                             })}
+                            {showBaseline && (
+                                <TableCell className="text-center text-sm font-semibold bg-gray-50">
+                                    {(total?.baselineHours || 0) > 0 ? formatNumber(total?.baselineHours || 0) : "-"}
+                                </TableCell>
+                            )}
                             <TableCell className="text-center text-sm font-semibold bg-gray-50">
                                 {formatNumber(total?.plannedHours || 0)}
                             </TableCell>
                             <TableCell className="text-center text-sm font-semibold bg-gray-50">
                                 {formatNumber(total?.actualHours || 0)}
+                                {showDifference && (
+                                    <span className={`ml-1 font-normal ${getDifferenceColor(total?.difference || 0)}`}>
+                                        ({formatSignedDifference(total?.difference || 0)})
+                                    </span>
+                                )}
                             </TableCell>
-                            <TableCell
-                                className={`text-center text-sm font-semibold bg-gray-50 ${getDifferenceColor(total?.difference || 0)}`}
-                            >
-                                {formatNumber(total?.difference || 0)}
-                            </TableCell>
+                            {showForecast && (
+                                <TableCell className="text-center text-sm font-semibold bg-gray-50">
+                                    {(total?.forecastHours || 0) > 0 ? (
+                                        <>
+                                            {formatNumber(total?.forecastHours || 0)}
+                                            {showDifference && (
+                                                <span className={`ml-1 font-normal ${getDifferenceColor((total?.forecastHours || 0) - (total?.plannedHours || 0))}`}>
+                                                    ({formatSignedDifference((total?.forecastHours || 0) - (total?.plannedHours || 0))})
+                                                </span>
+                                            )}
+                                        </>
+                                    ) : (
+                                        "-"
+                                    )}
+                                </TableCell>
+                            )}
                         </TableRow>
                     );
                 })}
@@ -228,49 +284,76 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                         const total = monthlyTotals[m] || ({} as SummaryCell);
                         const baseline = total.baselineHours || 0;
                         const forecast = total.forecastHours || 0;
+                        const planned = total.plannedHours || 0;
+                        const actual = total.actualHours || 0;
+                        const diff = total.difference || 0;
+                        const forecastDiff = forecast - planned;
                         return (
                             <React.Fragment key={m}>
                                 {showBaseline && (
-                                    <TableCell className={`text-center text-sm ${!showForecast ? "border-r" : ""}`}>
+                                    <TableCell className="text-center text-sm">
                                         {baseline > 0 ? formatNumber(baseline) : "-"}
                                     </TableCell>
                                 )}
                                 <TableCell className="text-center text-sm">
-                                    {formatNumber(total.plannedHours || 0)}
+                                    {formatNumber(planned)}
                                 </TableCell>
                                 <TableCell
-                                    className={`text-center text-sm ${!showDifference && !showBaseline && !showForecast ? "border-r" : ""}`}
+                                    className={`text-center text-sm ${!showForecast ? "border-r" : ""}`}
                                 >
-                                    {formatNumber(total.actualHours || 0)}
+                                    {formatNumber(actual)}
+                                    {showDifference && (
+                                        <span className={`ml-1 font-normal ${getDifferenceColor(diff)}`}>
+                                            ({formatSignedDifference(diff)})
+                                        </span>
+                                    )}
                                 </TableCell>
-                                {showDifference && (
-                                    <TableCell
-                                        className={`text-center text-sm ${getDifferenceColor(total.difference || 0)} ${!showBaseline && !showForecast ? "border-r" : ""}`}
-                                    >
-                                        {formatNumber(total.difference || 0)}
-                                    </TableCell>
-                                )}
-
                                 {showForecast && (
                                     <TableCell className="text-center text-sm border-r">
                                         {formatNumber(forecast)}
+                                        {showDifference && (
+                                            <span className={`ml-1 font-normal ${getDifferenceColor(forecastDiff)}`}>
+                                                ({formatSignedDifference(forecastDiff)})
+                                            </span>
+                                        )}
                                     </TableCell>
                                 )}
                             </React.Fragment>
                         );
                     })}
                     {/* 全体合計 */}
+                    {showBaseline && (
+                        <TableCell className="text-center text-sm bg-gray-200">
+                            {(grandTotal.baselineHours || 0) > 0 ? formatNumber(grandTotal.baselineHours || 0) : "-"}
+                        </TableCell>
+                    )}
                     <TableCell className="text-center text-sm bg-gray-200">
                         {formatNumber(grandTotal.plannedHours)}
                     </TableCell>
                     <TableCell className="text-center text-sm bg-gray-200">
                         {formatNumber(grandTotal.actualHours)}
+                        {showDifference && (
+                            <span className={`ml-1 font-normal ${getDifferenceColor(grandTotal.difference)}`}>
+                                ({formatSignedDifference(grandTotal.difference)})
+                            </span>
+                        )}
                     </TableCell>
-                    <TableCell
-                        className={`text-center text-sm bg-gray-200 ${getDifferenceColor(grandTotal.difference)}`}
-                    >
-                        {formatNumber(grandTotal.difference)}
-                    </TableCell>
+                    {showForecast && (
+                        <TableCell className="text-center text-sm bg-gray-200">
+                            {(grandTotal.forecastHours || 0) > 0 ? (
+                                <>
+                                    {formatNumber(grandTotal.forecastHours || 0)}
+                                    {showDifference && (
+                                        <span className={`ml-1 font-normal ${getDifferenceColor((grandTotal.forecastHours || 0) - grandTotal.plannedHours)}`}>
+                                            ({formatSignedDifference((grandTotal.forecastHours || 0) - grandTotal.plannedHours)})
+                                        </span>
+                                    )}
+                                </>
+                            ) : (
+                                "-"
+                            )}
+                        </TableCell>
+                    )}
                 </TableRow>
             </TableBody>
         </Table>

--- a/src/utils/export-table.ts
+++ b/src/utils/export-table.ts
@@ -239,21 +239,29 @@ interface MonthlyAssigneeData {
     plannedHours: number;
     actualHours: number;
     difference: number;
+    baselineHours?: number;
+    forecastHours?: number;
   }>;
   monthlyTotals: Record<string, {
     plannedHours: number;
     actualHours: number;
     difference: number;
+    baselineHours?: number;
+    forecastHours?: number;
   }>;
   assigneeTotals: Record<string, {
     plannedHours: number;
     actualHours: number;
     difference: number;
+    baselineHours?: number;
+    forecastHours?: number;
   }>;
   grandTotal: {
     plannedHours: number;
     actualHours: number;
     difference: number;
+    baselineHours?: number;
+    forecastHours?: number;
   };
 }
 
@@ -267,12 +275,20 @@ export async function copyMonthlyAssigneeSummaryToClipboard(
   unit: HoursUnit = 'hours'
 ): Promise<void> {
   const unitSuffix = getUnitSuffix(unit);
+  const fmt = (v: number) =>
+    convertHours(v, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
   const headers = [
     '担当者',
-    ...data.months.flatMap(month => [`${month}_予定(${unitSuffix})`, `${month}_実績(${unitSuffix})`, `${month}_差分`]),
+    ...data.months.flatMap(month => [
+      `${month}_基準(${unitSuffix})`,
+      `${month}_予定(${unitSuffix})`,
+      `${month}_実績(${unitSuffix})`,
+      `${month}_見通し(${unitSuffix})`,
+    ]),
+    `合計_基準(${unitSuffix})`,
     `合計_予定(${unitSuffix})`,
     `合計_実績(${unitSuffix})`,
-    '合計_差分'
+    `合計_見通し(${unitSuffix})`,
   ];
 
   const rows = [
@@ -282,17 +298,19 @@ export async function copyMonthlyAssigneeSummaryToClipboard(
       data.months.forEach(month => {
         const monthData = data.data.find(d => d.month === month && d.assignee === assignee);
         row.push(
-          convertHours(monthData?.plannedHours || 0, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-          convertHours(monthData?.actualHours || 0, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-          convertHours(monthData?.difference || 0, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+          fmt(monthData?.baselineHours || 0),
+          fmt(monthData?.plannedHours || 0),
+          fmt(monthData?.actualHours || 0),
+          fmt(monthData?.forecastHours || 0)
         );
       });
 
       const assigneeTotal = data.assigneeTotals[assignee];
       row.push(
-        convertHours(assigneeTotal.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-        convertHours(assigneeTotal.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-        convertHours(assigneeTotal.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+        fmt(assigneeTotal?.baselineHours || 0),
+        fmt(assigneeTotal?.plannedHours || 0),
+        fmt(assigneeTotal?.actualHours || 0),
+        fmt(assigneeTotal?.forecastHours || 0)
       );
 
       return row;
@@ -302,14 +320,16 @@ export async function copyMonthlyAssigneeSummaryToClipboard(
       ...data.months.flatMap(month => {
         const total = data.monthlyTotals[month];
         return [
-          convertHours(total.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-          convertHours(total.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-          convertHours(total.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+          fmt(total?.baselineHours || 0),
+          fmt(total?.plannedHours || 0),
+          fmt(total?.actualHours || 0),
+          fmt(total?.forecastHours || 0),
         ];
       }),
-      convertHours(data.grandTotal.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-      convertHours(data.grandTotal.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-      convertHours(data.grandTotal.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+      fmt(data.grandTotal.baselineHours || 0),
+      fmt(data.grandTotal.plannedHours),
+      fmt(data.grandTotal.actualHours),
+      fmt(data.grandTotal.forecastHours || 0),
     ]
   ];
 
@@ -330,10 +350,16 @@ export function exportMonthlyAssigneeSummary(
   const unitSuffix = getUnitSuffix(unit);
   const headers = [
     '担当者',
-    ...data.months.flatMap(month => [`${month}_予定(${unitSuffix})`, `${month}_実績(${unitSuffix})`, `${month}_差分`]),
+    ...data.months.flatMap(month => [
+      `${month}_基準(${unitSuffix})`,
+      `${month}_予定(${unitSuffix})`,
+      `${month}_実績(${unitSuffix})`,
+      `${month}_見通し(${unitSuffix})`,
+    ]),
+    `合計_基準(${unitSuffix})`,
     `合計_予定(${unitSuffix})`,
     `合計_実績(${unitSuffix})`,
-    '合計_差分'
+    `合計_見通し(${unitSuffix})`,
   ];
 
   const rows = [
@@ -343,17 +369,19 @@ export function exportMonthlyAssigneeSummary(
       data.months.forEach(month => {
         const monthData = data.data.find(d => d.month === month && d.assignee === assignee);
         row.push(
+          convertHours(monthData?.baselineHours || 0, unit),
           convertHours(monthData?.plannedHours || 0, unit),
           convertHours(monthData?.actualHours || 0, unit),
-          convertHours(monthData?.difference || 0, unit)
+          convertHours(monthData?.forecastHours || 0, unit)
         );
       });
 
       const assigneeTotal = data.assigneeTotals[assignee];
       row.push(
-        convertHours(assigneeTotal.plannedHours, unit),
-        convertHours(assigneeTotal.actualHours, unit),
-        convertHours(assigneeTotal.difference, unit)
+        convertHours(assigneeTotal?.baselineHours || 0, unit),
+        convertHours(assigneeTotal?.plannedHours || 0, unit),
+        convertHours(assigneeTotal?.actualHours || 0, unit),
+        convertHours(assigneeTotal?.forecastHours || 0, unit)
       );
 
       return row;
@@ -363,14 +391,16 @@ export function exportMonthlyAssigneeSummary(
       ...data.months.flatMap(month => {
         const total = data.monthlyTotals[month];
         return [
-          convertHours(total.plannedHours, unit),
-          convertHours(total.actualHours, unit),
-          convertHours(total.difference, unit)
+          convertHours(total?.baselineHours || 0, unit),
+          convertHours(total?.plannedHours || 0, unit),
+          convertHours(total?.actualHours || 0, unit),
+          convertHours(total?.forecastHours || 0, unit),
         ];
       }),
+      convertHours(data.grandTotal.baselineHours || 0, unit),
       convertHours(data.grandTotal.plannedHours, unit),
       convertHours(data.grandTotal.actualHours, unit),
-      convertHours(data.grandTotal.difference, unit)
+      convertHours(data.grandTotal.forecastHours || 0, unit)
     ]
   ];
 
@@ -386,6 +416,8 @@ interface MonthlyPhaseDataCell {
   plannedHours: number;
   actualHours: number;
   difference: number;
+  baselineHours?: number;
+  forecastHours?: number;
 }
 
 export interface MonthlyPhaseSummaryExportInput {
@@ -419,12 +451,20 @@ export async function copyMonthlyPhaseSummaryToClipboard(
   unit: HoursUnit = 'hours'
 ): Promise<void> {
   const unitSuffix = getUnitSuffix(unit);
+  const fmt = (v: number) =>
+    convertHours(v, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
   const headers = [
     '工程',
-    ...data.months.flatMap(month => [`${month}_予定(${unitSuffix})`, `${month}_実績(${unitSuffix})`, `${month}_差分`]),
+    ...data.months.flatMap(month => [
+      `${month}_基準(${unitSuffix})`,
+      `${month}_予定(${unitSuffix})`,
+      `${month}_実績(${unitSuffix})`,
+      `${month}_見通し(${unitSuffix})`,
+    ]),
+    `合計_基準(${unitSuffix})`,
     `合計_予定(${unitSuffix})`,
     `合計_実績(${unitSuffix})`,
-    '合計_差分'
+    `合計_見通し(${unitSuffix})`,
   ];
 
   const rows = [
@@ -433,16 +473,18 @@ export async function copyMonthlyPhaseSummaryToClipboard(
       data.months.forEach(month => {
         const cell = getCellFromContainer(data.cells, `${month}|${phase}`);
         row.push(
-          convertHours(cell?.plannedHours || 0, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-          convertHours(cell?.actualHours || 0, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-          convertHours(cell?.difference || 0, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+          fmt(cell?.baselineHours || 0),
+          fmt(cell?.plannedHours || 0),
+          fmt(cell?.actualHours || 0),
+          fmt(cell?.forecastHours || 0)
         );
       });
       const total = data.phaseTotals[phase];
       row.push(
-        convertHours(total?.plannedHours || 0, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-        convertHours(total?.actualHours || 0, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-        convertHours(total?.difference || 0, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+        fmt(total?.baselineHours || 0),
+        fmt(total?.plannedHours || 0),
+        fmt(total?.actualHours || 0),
+        fmt(total?.forecastHours || 0)
       );
       return row;
     }),
@@ -451,14 +493,16 @@ export async function copyMonthlyPhaseSummaryToClipboard(
       ...data.months.flatMap(month => {
         const total = data.monthlyTotals[month];
         return [
-          convertHours(total?.plannedHours || 0, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-          convertHours(total?.actualHours || 0, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-          convertHours(total?.difference || 0, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+          fmt(total?.baselineHours || 0),
+          fmt(total?.plannedHours || 0),
+          fmt(total?.actualHours || 0),
+          fmt(total?.forecastHours || 0),
         ];
       }),
-      convertHours(data.grandTotal.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-      convertHours(data.grandTotal.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-      convertHours(data.grandTotal.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+      fmt(data.grandTotal.baselineHours || 0),
+      fmt(data.grandTotal.plannedHours),
+      fmt(data.grandTotal.actualHours),
+      fmt(data.grandTotal.forecastHours || 0)
     ]
   ];
 
@@ -479,10 +523,16 @@ export function exportMonthlyPhaseSummary(
   const unitSuffix = getUnitSuffix(unit);
   const headers = [
     '工程',
-    ...data.months.flatMap(month => [`${month}_予定(${unitSuffix})`, `${month}_実績(${unitSuffix})`, `${month}_差分`]),
+    ...data.months.flatMap(month => [
+      `${month}_基準(${unitSuffix})`,
+      `${month}_予定(${unitSuffix})`,
+      `${month}_実績(${unitSuffix})`,
+      `${month}_見通し(${unitSuffix})`,
+    ]),
+    `合計_基準(${unitSuffix})`,
     `合計_予定(${unitSuffix})`,
     `合計_実績(${unitSuffix})`,
-    '合計_差分'
+    `合計_見通し(${unitSuffix})`,
   ];
 
   const rows = [
@@ -491,16 +541,18 @@ export function exportMonthlyPhaseSummary(
       data.months.forEach(month => {
         const cell = getCellFromContainer(data.cells, `${month}|${phase}`);
         row.push(
+          convertHours(cell?.baselineHours || 0, unit),
           convertHours(cell?.plannedHours || 0, unit),
           convertHours(cell?.actualHours || 0, unit),
-          convertHours(cell?.difference || 0, unit)
+          convertHours(cell?.forecastHours || 0, unit)
         );
       });
       const total = data.phaseTotals[phase];
       row.push(
+        convertHours(total?.baselineHours || 0, unit),
         convertHours(total?.plannedHours || 0, unit),
         convertHours(total?.actualHours || 0, unit),
-        convertHours(total?.difference || 0, unit)
+        convertHours(total?.forecastHours || 0, unit)
       );
       return row;
     }),
@@ -509,14 +561,16 @@ export function exportMonthlyPhaseSummary(
       ...data.months.flatMap(month => {
         const total = data.monthlyTotals[month];
         return [
+          convertHours(total?.baselineHours || 0, unit),
           convertHours(total?.plannedHours || 0, unit),
           convertHours(total?.actualHours || 0, unit),
-          convertHours(total?.difference || 0, unit)
+          convertHours(total?.forecastHours || 0, unit),
         ];
       }),
+      convertHours(data.grandTotal.baselineHours || 0, unit),
       convertHours(data.grandTotal.plannedHours, unit),
       convertHours(data.grandTotal.actualHours, unit),
-      convertHours(data.grandTotal.difference, unit)
+      convertHours(data.grandTotal.forecastHours || 0, unit)
     ]
   ];
 


### PR DESCRIPTION
## Summary
Refactored the monthly summary table display to show differences (actual vs planned, forecast vs planned) inline with their respective values rather than in separate columns. This improves readability and reduces table width while maintaining all information visibility.

## Key Changes

### Monthly Summary Table Component (`monthly-summary-table.tsx`)
- Added `formatSignedDifference()` utility function to format differences with proper sign notation (+/−/±) and unit conversion
- Removed separate "差分" (difference) column from table headers
- Updated column headers to conditionally display "実績(差分)" or "見通し(差分)" when `showDifference` is enabled
- Modified `monthColSpan` calculation to remove the difference column count
- Refactored data cells to display differences inline as colored subscript text next to actual/forecast values
- Updated both monthly detail rows and grand total rows to use the new inline difference display
- Improved border styling logic to account for removed difference column

### Export Functions (`export-table.ts`)
- Updated `MonthlyAssigneeData` and `MonthlyPhaseSummaryExportInput` interfaces to include optional `baselineHours` and `forecastHours` fields
- Refactored export headers to include baseline and forecast columns instead of separate difference columns
- Modified `copyMonthlyAssigneeSummaryToClipboard()` and `copyMonthlyPhaseSummaryToClipboard()` to export baseline, planned, actual, and forecast values
- Updated `exportMonthlyAssigneeSummary()` and `exportMonthlyPhaseSummary()` with the same column structure
- Introduced `fmt()` helper function for consistent number formatting in clipboard exports

### Summary Components
- Updated `MonthlyAssigneeSummary` and `MonthlyPhaseSummary` to pass `baselineHours` and `forecastHours` to export functions

## Implementation Details

- Differences are now displayed as colored inline text (red for overage, green for exact match, blue for underage) using the existing `getDifferenceColor()` function
- The `formatSignedDifference()` function properly handles unit conversion and locale-specific number formatting (Japanese locale with 2 decimal places)
- Export functionality now provides more granular data (baseline and forecast) rather than pre-calculated differences, allowing consumers to compute differences as needed
- Table layout is more compact while maintaining visual hierarchy through background colors and font weights

https://claude.ai/code/session_01E86BkkZ5yQtHAQPn72iac9