### PR TITLE
Fix timezone issue in Geppo import work record date generation

### DIFF
--- a/src/__tests__/applications/geppo-import/create-utc-date-from-year-month-day.test.ts
+++ b/src/__tests__/applications/geppo-import/create-utc-date-from-year-month-day.test.ts
@@ -1,0 +1,33 @@
+import { createUtcDateFromYearMonthDay } from '@/applications/geppo-import/geppo-import-application-service'
+
+/**
+ * Geppoインポートの実績日（WorkRecord.date）生成のTZ安全性を検証する。
+ *
+ * WorkRecord.date は `@db.Date` に UTC の暦日として保存されるため、
+ * 生成した Date は実行環境のTZに依らず UTC 0時でなければならない。
+ * （旧実装 `new Date(year, month, day)` は JST 等で前日ずれを起こしていた。
+ *  Issue #48: ガント上の実績日が1日ずれる）
+ */
+describe('createUtcDateFromYearMonthDay', () => {
+  it('YYYYMM＋日を UTC 0時の Date として生成する', () => {
+    const d = createUtcDateFromYearMonthDay('202509', 3)
+    // TZに依存しない絶対値で検証する
+    expect(d.toISOString()).toBe('2025-09-03T00:00:00.000Z')
+  })
+
+  it('月初・月末でもUTC暦日が保たれる', () => {
+    expect(createUtcDateFromYearMonthDay('202501', 1).toISOString()).toBe(
+      '2025-01-01T00:00:00.000Z',
+    )
+    expect(createUtcDateFromYearMonthDay('202512', 31).toISOString()).toBe(
+      '2025-12-31T00:00:00.000Z',
+    )
+  })
+
+  it('UTCの暦日成分が入力値と一致する（ローカルTZの影響を受けない）', () => {
+    const d = createUtcDateFromYearMonthDay('202509', 3)
+    expect(d.getUTCFullYear()).toBe(2025)
+    expect(d.getUTCMonth()).toBe(8) // 0ベース: 9月
+    expect(d.getUTCDate()).toBe(3)
+  })
+})

--- a/src/applications/geppo-import/geppo-import-application-service.ts
+++ b/src/applications/geppo-import/geppo-import-application-service.ts
@@ -17,6 +17,21 @@ import type { ITaskMappingService, TaskMappingEntry } from '@/applications/geppo
 import { buildTaskMapKey } from '@/applications/geppo-import/itask-mapping-service'
 import { Geppo, GeppoSearchFilters } from '@/domains/geppo/types'
 
+/**
+ * GeppoのYYYYMM＋日から作業実績日（WorkRecord.date）用のDateを生成する。
+ *
+ * WorkRecord.date は Prisma の `@db.Date`（TZなしの暦日）に保存され、Prisma は
+ * Date の **UTC** の暦日を書き込む。`new Date(year, month, day)` はローカルTZの
+ * 0時を表すため、UTC+9(JST)等の環境で生成すると前日（例: 9/3→9/2）として
+ * 保存され、ガントチャート上の実績日が1日ずれる原因になる。
+ * 日付ポリシー（保存は常にUTC）に従い、`Date.UTC` でUTC 0時として構築する。
+ */
+export function createUtcDateFromYearMonthDay(yyyymm: string, day: number): Date {
+  const year = parseInt(yyyymm.substring(0, 4))
+  const month = parseInt(yyyymm.substring(4, 6)) - 1 // Dateは0ベース
+  return new Date(Date.UTC(year, month, day))
+}
+
 export interface IGeppoImportApplicationService {
   validateImportData(options: GeppoImportOptions): Promise<GeppoImportValidation>
   executeImport(options: GeppoImportOptions): Promise<GeppoImportResult>
@@ -334,14 +349,12 @@ export class GeppoImportApplicationService implements IGeppoImportApplicationSer
 
   /**
    * YYYYMMと日付からDateオブジェクトを作成
-   * @param yyyymm 
-   * @param day 
-   * @returns 
+   * @param yyyymm
+   * @param day
+   * @returns
    */
   private createDateFromYearMonthDay(yyyymm: string, day: number): Date {
-    const year = parseInt(yyyymm.substring(0, 4))
-    const month = parseInt(yyyymm.substring(4, 6)) - 1 // Dateは0ベース
-    return new Date(year, month, day)
+    return createUtcDateFromYearMonthDay(yyyymm, day)
   }
 
   private convertWorkRecordsToImportRecords(workRecords: WorkRecord[]): GeppoImportRecord[] {


### PR DESCRIPTION
## Summary
Fixes a timezone-dependent bug in Geppo import where work record dates were being created with `new Date(year, month, day)`, causing dates to shift by one day in UTC+9 (JST) and other non-UTC timezones. The fix implements UTC-safe date creation following the project's timezone policy.

## Changes
- **New function `createUtcDateFromYearMonthDay()`**: Extracts and exports the date creation logic using `Date.UTC()` to ensure dates are always created at UTC 0:00, regardless of the execution environment's timezone
- **Updated `createDateFromYearMonthDay()` private method**: Now delegates to the new exported function for consistency
- **Added comprehensive test suite**: Tests verify that:
  - Dates are created at UTC 0:00 (via `toISOString()` validation)
  - Month boundaries (1st and 31st) maintain correct UTC calendar dates
  - UTC date components match input values regardless of local timezone

## Implementation Details
- Uses `Date.UTC(year, month, day)` instead of `new Date(year, month, day)` to guarantee UTC-based date creation
- Follows the project's timezone policy: "保存は常に UTC" (always save as UTC)
- Addresses Issue #48: ガント上の実績日が1日ずれる (Gantt chart work record dates shifting by one day)
- Tests use `toISOString()` for timezone-independent validation, ensuring the fix works across all execution environments

https://claude.ai/code/session_012iZApHc3mAoPtaGg2YSzx2