### PR TITLE
Add forecast end date calculation for gantt chart visualization

### DIFF
--- a/src/__tests__/applications/forecast/forecast-application-service.test.ts
+++ b/src/__tests__/applications/forecast/forecast-application-service.test.ts
@@ -1,0 +1,207 @@
+import 'reflect-metadata';
+import { ForecastApplicationService } from '@/applications/forecast/forecast-application-service';
+import type {
+  IWbsQueryRepository,
+  WbsTaskData,
+} from '@/applications/wbs/query/iwbs-query-repository';
+import type { ISystemSettingsRepository } from '@/applications/system-settings/isystem-settings-repository';
+import type { ICompanyHolidayRepository } from '@/applications/calendar/icompany-holiday-repository';
+import { SystemSettings } from '@/domains/system-settings/system-settings';
+
+describe('ForecastApplicationService.calculateTasksForecastDates', () => {
+  let service: ForecastApplicationService;
+  let mockWbsQueryRepository: jest.Mocked<IWbsQueryRepository>;
+  let mockSystemSettingsRepository: jest.Mocked<ISystemSettingsRepository>;
+  let mockCompanyHolidayRepository: jest.Mocked<ICompanyHolidayRepository>;
+
+  // 2026-07-08 は水曜日（営業日）
+  const baseDate = new Date(2026, 6, 8);
+
+  const createTask = (overrides: Partial<WbsTaskData> = {}): WbsTaskData => ({
+    id: '1',
+    no: 'D1-0001',
+    name: 'テストタスク',
+    kijunKosu: null,
+    yoteiKosu: 20,
+    jissekiKosu: 10,
+    kijunStart: null,
+    kijunEnd: null,
+    yoteiStart: new Date(2026, 6, 1),
+    yoteiEnd: new Date(2026, 6, 15),
+    jissekiStart: new Date(2026, 6, 2),
+    jissekiEnd: null,
+    progressRate: 50,
+    status: 'IN_PROGRESS',
+    phase: null,
+    assignee: null,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    mockWbsQueryRepository = {
+      getWbsTasks: jest.fn().mockResolvedValue([]),
+      getPhases: jest.fn(),
+      getTaskActualHoursByMonth: jest.fn(),
+      getUnlinkedWorkRecordsCount: jest.fn(),
+    };
+    mockSystemSettingsRepository = {
+      get: jest.fn().mockResolvedValue(SystemSettings.create(7.5)),
+      update: jest.fn(),
+    };
+    mockCompanyHolidayRepository = {
+      findAll: jest.fn().mockResolvedValue([]),
+      findById: jest.fn(),
+      findByDateRange: jest.fn(),
+      findByDate: jest.fn(),
+      findByDateExcludingId: jest.fn(),
+      save: jest.fn(),
+      saveMany: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
+    service = new ForecastApplicationService(
+      mockWbsQueryRepository,
+      mockSystemSettingsRepository,
+      mockCompanyHolidayRepository
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('実績開始があり残工数が正の場合、開始日=実績開始日・終了日を営業日ベースで返す', async () => {
+    // realistic + 進捗50%: 見通し = 20/50*100*0.5 + (10 + 20*0.5)*0.5 = 20h → 残10h → 2営業日
+    mockWbsQueryRepository.getWbsTasks.mockResolvedValue([createTask()]);
+
+    const result = await service.calculateTasksForecastDates(
+      1,
+      { method: 'realistic', progressMeasurementMethod: 'SELF_REPORTED' },
+      baseDate
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].taskId).toBe('1');
+    expect(result[0].forecastHours).toBe(20);
+    expect(result[0].actualHours).toBe(10);
+    expect(result[0].remainingHours).toBe(10);
+    expect(result[0].forecastStartDate).toEqual(new Date(2026, 6, 2));
+    expect(result[0].forecastEndDate).toEqual(new Date(2026, 6, 9));
+  });
+
+  it('実績開始がないタスクは見通し日付をnullで返す', async () => {
+    mockWbsQueryRepository.getWbsTasks.mockResolvedValue([
+      createTask({ jissekiStart: null, jissekiKosu: null, status: 'NOT_STARTED', progressRate: 0 }),
+    ]);
+
+    const result = await service.calculateTasksForecastDates(1, undefined, baseDate);
+
+    expect(result[0].forecastStartDate).toBeNull();
+    expect(result[0].forecastEndDate).toBeNull();
+  });
+
+  it('完了タスクは見通し日付をnullで返す', async () => {
+    mockWbsQueryRepository.getWbsTasks.mockResolvedValue([
+      createTask({ status: 'COMPLETED', progressRate: 100, jissekiEnd: new Date(2026, 6, 5) }),
+    ]);
+
+    const result = await service.calculateTasksForecastDates(1, undefined, baseDate);
+
+    expect(result[0].forecastStartDate).toBeNull();
+    expect(result[0].forecastEndDate).toBeNull();
+  });
+
+  it('見通し工数が実績工数以下の場合は終了日をnullで返す', async () => {
+    // 進捗100%（未完了ステータス）→ 見通し = 実績 → 残0
+    mockWbsQueryRepository.getWbsTasks.mockResolvedValue([
+      createTask({ progressRate: 100 }),
+    ]);
+
+    const result = await service.calculateTasksForecastDates(
+      1,
+      { method: 'realistic', progressMeasurementMethod: 'SELF_REPORTED' },
+      baseDate
+    );
+
+    expect(result[0].remainingHours).toBe(0);
+    expect(result[0].forecastEndDate).toBeNull();
+  });
+
+  it('見通し算出方式(options.method)が反映される', async () => {
+    // 進捗25%・実績10h・予定20h
+    // conservative: 10/25*100 = 40h → 残30h → 4営業日(7/8,9,10,13) → 7/13
+    // optimistic: 10 + 20*0.75 = 25h → 残15h → 2営業日 → 7/9
+    const task = createTask({ progressRate: 25 });
+    mockWbsQueryRepository.getWbsTasks.mockResolvedValue([task]);
+
+    const conservative = await service.calculateTasksForecastDates(
+      1,
+      { method: 'conservative', progressMeasurementMethod: 'SELF_REPORTED' },
+      baseDate
+    );
+    const optimistic = await service.calculateTasksForecastDates(
+      1,
+      { method: 'optimistic', progressMeasurementMethod: 'SELF_REPORTED' },
+      baseDate
+    );
+
+    expect(conservative[0].forecastEndDate).toEqual(new Date(2026, 6, 13));
+    expect(optimistic[0].forecastEndDate).toEqual(new Date(2026, 6, 9));
+  });
+
+  it('システム設定の基本稼働時間が反映される', async () => {
+    // 残10h @4h/日 → 3営業日(7/8,9,10) → 7/10
+    mockSystemSettingsRepository.get.mockResolvedValue(SystemSettings.create(4));
+    mockWbsQueryRepository.getWbsTasks.mockResolvedValue([createTask()]);
+
+    const result = await service.calculateTasksForecastDates(
+      1,
+      { method: 'realistic', progressMeasurementMethod: 'SELF_REPORTED' },
+      baseDate
+    );
+
+    expect(result[0].forecastEndDate).toEqual(new Date(2026, 6, 10));
+  });
+
+  it('会社休日をスキップして終了日を算出する', async () => {
+    // 残10h @7.5h/日 → 2営業日。7/9が会社休日 → 7/8,7/10 → 7/10
+    mockCompanyHolidayRepository.findAll.mockResolvedValue([
+      { date: new Date(2026, 6, 9), name: '創立記念日', type: 'COMPANY' },
+    ]);
+    mockWbsQueryRepository.getWbsTasks.mockResolvedValue([createTask()]);
+
+    const result = await service.calculateTasksForecastDates(
+      1,
+      { method: 'realistic', progressMeasurementMethod: 'SELF_REPORTED' },
+      baseDate
+    );
+
+    expect(result[0].forecastEndDate).toEqual(new Date(2026, 6, 10));
+  });
+
+  it('複数タスクでも各リポジトリの呼び出しは1回ずつ(N+1なし)', async () => {
+    mockWbsQueryRepository.getWbsTasks.mockResolvedValue([
+      createTask({ id: '1' }),
+      createTask({ id: '2' }),
+      createTask({ id: '3' }),
+    ]);
+
+    const result = await service.calculateTasksForecastDates(1, undefined, baseDate);
+
+    expect(result).toHaveLength(3);
+    expect(mockWbsQueryRepository.getWbsTasks).toHaveBeenCalledTimes(1);
+    expect(mockSystemSettingsRepository.get).toHaveBeenCalledTimes(1);
+    expect(mockCompanyHolidayRepository.findAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('taskIdは文字列に正規化される($queryRaw由来でnumberの場合がある)', async () => {
+    mockWbsQueryRepository.getWbsTasks.mockResolvedValue([
+      createTask({ id: 123 as unknown as string }),
+    ]);
+
+    const result = await service.calculateTasksForecastDates(1, undefined, baseDate);
+
+    expect(result[0].taskId).toBe('123');
+  });
+});

--- a/src/__tests__/components/ganttv3/GanttChart.test.tsx
+++ b/src/__tests__/components/ganttv3/GanttChart.test.tsx
@@ -90,6 +90,75 @@ describe("GanttChart", () => {
     });
   });
 
+  describe("見通しバーの描画", () => {
+    const tasksWithForecast = [
+      makeTask({
+        id: "1",
+        name: "タスクA",
+        category: "設計",
+        startDate: new Date("2024-01-01T00:00:00.000Z"),
+        endDate: new Date("2024-01-03T00:00:00.000Z"),
+        actualStartDate: new Date("2024-01-02T00:00:00.000Z"),
+        actualEndDate: new Date("2024-01-04T00:00:00.000Z"),
+        forecastStartDate: new Date("2024-01-02T00:00:00.000Z"),
+        forecastEndDate: new Date("2024-01-08T00:00:00.000Z"),
+      }),
+      makeTask({
+        id: "2",
+        name: "タスクB",
+        category: "設計",
+        startDate: new Date("2024-01-05T00:00:00.000Z"),
+        endDate: new Date("2024-01-10T00:00:00.000Z"),
+      }),
+    ];
+
+    it("showForecast ON かつ見通し日付ありのタスクに破線の見通しバーを描画する", () => {
+      const { container } = render(
+        <GanttChart
+          {...defaultProps}
+          tasks={tasksWithForecast}
+          style={makeStyle({
+            showDependencies: false,
+            showTodayLine: false,
+            showForecast: true,
+          })}
+        />,
+      );
+      const bars = container.querySelectorAll(
+        '[data-testid="ganttv3-forecast-bar"]',
+      );
+      // 見通し日付を持つタスクAのみ描画される（タスクBには描画されない）
+      expect(bars).toHaveLength(1);
+      expect(bars[0].querySelector("rect")).toHaveAttribute(
+        "stroke-dasharray",
+      );
+    });
+
+    it("showForecast OFF では見通しバーを描画しない", () => {
+      const { container } = render(
+        <GanttChart {...defaultProps} tasks={tasksWithForecast} />,
+      );
+      expect(
+        container.querySelectorAll('[data-testid="ganttv3-forecast-bar"]'),
+      ).toHaveLength(0);
+    });
+
+    it("showForecast ON でも行の予定バーは通常どおり描画される", () => {
+      const { container } = render(
+        <GanttChart
+          {...defaultProps}
+          tasks={tasksWithForecast}
+          style={makeStyle({
+            showDependencies: false,
+            showTodayLine: false,
+            showForecast: true,
+          })}
+        />,
+      );
+      expect(container.querySelectorAll("[data-task-id]")).toHaveLength(2);
+    });
+  });
+
   describe("ズーム操作", () => {
     it("ズームイン/アウトで onZoomChange が 1.2倍/÷1.2 で発火", () => {
       const onZoomChange = jest.fn();

--- a/src/__tests__/components/ganttv3/QuickActions.test.tsx
+++ b/src/__tests__/components/ganttv3/QuickActions.test.tsx
@@ -53,6 +53,7 @@ describe("QuickActions", () => {
     ["クリティカルパス表示", "showCriticalPath"],
     ["本日ライン表示", "showTodayLine"],
     ["実績バー表示（予定の下段に実績を表示）", "showActual"],
+    ["見通しバー表示（実績の下段に見通しを表示）", "showForecast"],
   ] as const)("%s ボタンで %s がトグルされる", (title, flag) => {
     const style = makeStyle();
     render(<QuickActions {...baseProps} style={style} />);

--- a/src/__tests__/components/ganttv3/_fixtures.ts
+++ b/src/__tests__/components/ganttv3/_fixtures.ts
@@ -45,6 +45,7 @@ export function makeStyle(overrides: Partial<GanttStyle> = {}): GanttStyle {
     showGrid: true,
     showProgress: true,
     showActual: false,
+    showForecast: false,
     showDependencies: true,
     showCriticalPath: true,
     showWeekends: true,

--- a/src/__tests__/domains/forecast/forecast-date-calculation-service.test.ts
+++ b/src/__tests__/domains/forecast/forecast-date-calculation-service.test.ts
@@ -1,0 +1,125 @@
+import { ForecastDateCalculationService } from '@/domains/forecast/forecast-date-calculation-service';
+import { CompanyCalendar, CompanyHoliday } from '@/domains/calendar/company-calendar';
+
+describe('ForecastDateCalculationService', () => {
+  const calendar = new CompanyCalendar(7.5);
+
+  describe('calculateForecastEndDate', () => {
+    it('残工数が2営業日分の場合、基準日当日から消化し翌営業日が終了日になる', () => {
+      // 2026-07-08 は水曜日（営業日）。残15h = 7.5h × 2営業日
+      const end = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 15, actualHours: 0, baseDate: new Date(2026, 6, 8) },
+        calendar
+      );
+      expect(end).toEqual(new Date(2026, 6, 9));
+    });
+
+    it('残工数が1日分以下の場合、基準日当日が終了日になる', () => {
+      const end = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 4, actualHours: 0, baseDate: new Date(2026, 6, 8) },
+        calendar
+      );
+      expect(end).toEqual(new Date(2026, 6, 8));
+    });
+
+    it('実績工数を差し引いた残工数で計算する', () => {
+      // 残 = 20 - 5 = 15h = 2営業日
+      const end = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 20, actualHours: 5, baseDate: new Date(2026, 6, 8) },
+        calendar
+      );
+      expect(end).toEqual(new Date(2026, 6, 9));
+    });
+
+    it('土日をスキップして消化する', () => {
+      // 2026-07-10 は金曜日。残15h → 金曜 + 月曜(7/13)
+      const end = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 15, actualHours: 0, baseDate: new Date(2026, 6, 10) },
+        calendar
+      );
+      expect(end).toEqual(new Date(2026, 6, 13));
+    });
+
+    it('日本の祝日をスキップして消化する', () => {
+      // 2026-07-17 は金曜日。土日 + 2026-07-20 海の日(月曜)をスキップ → 火曜(7/21)
+      const end = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 15, actualHours: 0, baseDate: new Date(2026, 6, 17) },
+        calendar
+      );
+      expect(end).toEqual(new Date(2026, 6, 21));
+    });
+
+    it('会社独自休日をスキップして消化する', () => {
+      const holidays: CompanyHoliday[] = [
+        { date: new Date(2026, 6, 9), name: '創立記念日', type: 'COMPANY' },
+      ];
+      const calendarWithHoliday = new CompanyCalendar(7.5, holidays);
+      // 木曜(7/9)が会社休日 → 水曜(7/8) + 金曜(7/10)
+      const end = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 15, actualHours: 0, baseDate: new Date(2026, 6, 8) },
+        calendarWithHoliday
+      );
+      expect(end).toEqual(new Date(2026, 6, 10));
+    });
+
+    it('基準日自体が休日の場合、翌営業日から消化する', () => {
+      // 2026-07-11 は土曜日。残7.5h → 月曜(7/13)
+      const end = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 7.5, actualHours: 0, baseDate: new Date(2026, 6, 11) },
+        calendar
+      );
+      expect(end).toEqual(new Date(2026, 6, 13));
+    });
+
+    it('基準日の時刻成分は無視される（日単位で計算）', () => {
+      const end = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 15, actualHours: 0, baseDate: new Date(2026, 6, 8, 14, 30, 45) },
+        calendar
+      );
+      expect(end).toEqual(new Date(2026, 6, 9));
+    });
+
+    it('端数時間は切り上げて営業日を消化する', () => {
+      // 残7.6h @7.5h/日 → 2営業日
+      const end = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 7.6, actualHours: 0, baseDate: new Date(2026, 6, 8) },
+        calendar
+      );
+      expect(end).toEqual(new Date(2026, 6, 9));
+    });
+
+    it('見通し工数が実績工数以下の場合はnullを返す', () => {
+      const equal = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 10, actualHours: 10, baseDate: new Date(2026, 6, 8) },
+        calendar
+      );
+      const less = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 8, actualHours: 10, baseDate: new Date(2026, 6, 8) },
+        calendar
+      );
+      expect(equal).toBeNull();
+      expect(less).toBeNull();
+    });
+
+    it('見通し工数が0の場合はnullを返す', () => {
+      const end = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 0, actualHours: 0, baseDate: new Date(2026, 6, 8) },
+        calendar
+      );
+      expect(end).toBeNull();
+    });
+
+    it('異常に大きい残工数でも無限ループせず上限日で打ち切る', () => {
+      const end = ForecastDateCalculationService.calculateForecastEndDate(
+        { forecastHours: 1_000_000, actualHours: 0, baseDate: new Date(2026, 6, 8) },
+        calendar
+      );
+      expect(end).not.toBeNull();
+      const capDate = new Date(2026, 6, 8);
+      capDate.setDate(
+        capDate.getDate() + ForecastDateCalculationService.MAX_LOOKAHEAD_DAYS
+      );
+      expect(end!.getTime()).toBeLessThanOrEqual(capDate.getTime());
+    });
+  });
+});

--- a/src/app/wbs/[id]/ganttv3/actions.ts
+++ b/src/app/wbs/[id]/ganttv3/actions.ts
@@ -11,7 +11,9 @@ import type { ITaskDependencyService } from "@/applications/task-dependency/task
 import { DependencyType } from "@/components/ganttv3/gantt";
 import { statusColor } from "@/components/ganttv3/utils/taskFormat";
 import { ProgressMeasurementMethod } from "@/types/progress-measurement";
+import { ForecastCalculationMethod, toForecastMethodOption } from "@/types/forecast-calculation-method";
 import type { IProjectSettingsApplicationService } from "@/applications/project-settings/project-settings-application-service";
+import type { IForecastApplicationService } from "@/applications/forecast/forecast-application-service";
 
 // フェーズ色用の固定パレット（seq/index順に決定的に割り当てる）
 const PHASE_COLOR_PALETTE = [
@@ -35,13 +37,46 @@ export async function getGanttTasks(wbsId: number): Promise<GanttTask[]> {
     const tasks = await taskService.getTaskAll(wbsId);
     const milestones = await milestoneService.getMilestones(wbsId);
 
-    // プロジェクトの進捗測定方式を取得（進捗率の算出に使用。未設定は自己申告）
-    const progressMethod = await getProgressMeasurementMethod(wbsId);
+    // プロジェクトの進捗測定方式・見通し工数算出方式を取得（未設定は既定値）
+    const { progressMeasurementMethod, forecastCalculationMethod } =
+        await getProjectGanttSettings(wbsId);
 
     const ganttTasks: GanttTask[] = [
         ...milestones.map(convertMilestone).filter((milestone): milestone is GanttTask => milestone !== undefined),
-        ...tasks.map((task) => convertTask(task, progressMethod, taskService)).filter((task): task is GanttTask => task !== undefined)
+        ...tasks.map((task) => convertTask(task, progressMeasurementMethod, taskService)).filter((task): task is GanttTask => task !== undefined)
     ];
+
+    // 見通しバー用の日付を付与する（実績があり残工数が正のタスクのみ）
+    try {
+        const forecastService = container.get<IForecastApplicationService>(
+            SYMBOL.IForecastApplicationService
+        );
+        const forecastDates = await forecastService.calculateTasksForecastDates(
+            wbsId,
+            {
+                method: toForecastMethodOption(forecastCalculationMethod),
+                progressMeasurementMethod,
+            }
+        );
+        const forecastByTaskId = new Map(
+            forecastDates.map((forecast) => [forecast.taskId, forecast])
+        );
+
+        for (const task of ganttTasks) {
+            if (task.isMilestone || task.dbId === undefined) continue;
+            const forecast = forecastByTaskId.get(String(task.dbId));
+            if (
+                forecast?.forecastEndDate &&
+                task.actualStartDate
+            ) {
+                // 開始日は実績バーと揃えるため gantt タスク側の実績開始日を使う
+                task.forecastStartDate = task.actualStartDate;
+                task.forecastEndDate = forecast.forecastEndDate;
+            }
+        }
+    } catch (e) {
+        console.error("見通し日付の取得に失敗しました", e);
+    }
 
     // タスクバーの色をフェーズ色（getPhases と同じパレット・順序）に合わせる
     try {
@@ -158,24 +193,34 @@ export async function getPhases(wbsId: number): Promise<GanttPhase[]> {
     }));
 }
 
-// WBS（プロジェクト）の進捗測定方式を取得する。未設定時は自己申告進捗率。
-async function getProgressMeasurementMethod(
-    wbsId: number
-): Promise<ProgressMeasurementMethod> {
+// WBS（プロジェクト）の進捗測定方式・見通し工数算出方式を取得する。
+// 未設定・取得失敗時は既定値（自己申告進捗率／現実的）。
+async function getProjectGanttSettings(wbsId: number): Promise<{
+    progressMeasurementMethod: ProgressMeasurementMethod;
+    forecastCalculationMethod: ForecastCalculationMethod;
+}> {
+    const defaults = {
+        progressMeasurementMethod: "SELF_REPORTED" as const,
+        forecastCalculationMethod: "REALISTIC" as const,
+    };
     try {
         const wbsService = container.get<IWbsApplicationService>(
             SYMBOL.IWbsApplicationService
         );
         const wbs = await wbsService.getWbsById(wbsId);
-        if (!wbs) return "SELF_REPORTED";
+        if (!wbs) return defaults;
 
         const projectSettingsService = container.get<IProjectSettingsApplicationService>(
             SYMBOL.IProjectSettingsApplicationService
         );
-        return await projectSettingsService.getProgressMeasurementMethod(wbs.projectId);
+        const settings = await projectSettingsService.getProjectSettings(wbs.projectId);
+        return {
+            progressMeasurementMethod: settings.progressMeasurementMethod,
+            forecastCalculationMethod: settings.forecastCalculationMethod,
+        };
     } catch (e) {
-        console.error("進捗測定方式の取得に失敗しました", e);
-        return "SELF_REPORTED";
+        console.error("プロジェクト設定の取得に失敗しました", e);
+        return defaults;
     }
 }
 

--- a/src/applications/forecast/forecast-application-service.ts
+++ b/src/applications/forecast/forecast-application-service.ts
@@ -1,12 +1,31 @@
 import { injectable, inject } from 'inversify';
 import { SYMBOL } from '@/types/symbol';
 import type { IWbsQueryRepository } from '@/applications/wbs/query/iwbs-query-repository';
+import type { ISystemSettingsRepository } from '@/applications/system-settings/isystem-settings-repository';
+import type { ICompanyHolidayRepository } from '@/applications/calendar/icompany-holiday-repository';
 import { toForecastTaskInput } from '@/applications/wbs/query/to-forecast-task-input';
 import { ForecastCalculationService } from '@/domains/forecast/forecast-calculation-service';
+import { ForecastDateCalculationService } from '@/domains/forecast/forecast-date-calculation-service';
+import { CompanyCalendar } from '@/domains/calendar/company-calendar';
 import type {
   ForecastCalculationOptions,
   ForecastCalculationResult,
 } from '@/types/forecast-calculation';
+
+/**
+ * タスクごとの見通し日付（ガントチャートの見通しバー用）
+ */
+export interface TaskForecastDate {
+  /** wbs_task.id の文字列表現 */
+  taskId: string;
+  forecastHours: number;
+  actualHours: number;
+  remainingHours: number;
+  /** 実績開始日。実績未入力・完了タスクは null */
+  forecastStartDate: Date | null;
+  /** 残工数を基準稼働時間で消化し終える営業日。残0以下は null */
+  forecastEndDate: Date | null;
+}
 
 export interface IForecastApplicationService {
   calculateTasksForecast(
@@ -20,6 +39,12 @@ export interface IForecastApplicationService {
     options?: ForecastCalculationOptions
   ): Promise<ForecastCalculationResult | null>;
 
+  calculateTasksForecastDates(
+    wbsId: number,
+    options?: ForecastCalculationOptions,
+    baseDate?: Date
+  ): Promise<TaskForecastDate[]>;
+
   getForecastMethods(): Promise<
     ReadonlyArray<{ value: string; label: string; description: string }>
   >;
@@ -29,7 +54,11 @@ export interface IForecastApplicationService {
 export class ForecastApplicationService implements IForecastApplicationService {
   constructor(
     @inject(SYMBOL.IWbsQueryRepository)
-    private readonly wbsQueryRepository: IWbsQueryRepository
+    private readonly wbsQueryRepository: IWbsQueryRepository,
+    @inject(SYMBOL.ISystemSettingsRepository)
+    private readonly systemSettingsRepository: ISystemSettingsRepository,
+    @inject(SYMBOL.ICompanyHolidayRepository)
+    private readonly companyHolidayRepository: ICompanyHolidayRepository
   ) {}
 
   async calculateTasksForecast(
@@ -58,6 +87,61 @@ export class ForecastApplicationService implements IForecastApplicationService {
       toForecastTaskInput(task),
       options
     );
+  }
+
+  async calculateTasksForecastDates(
+    wbsId: number,
+    options: ForecastCalculationOptions = { method: 'realistic' },
+    baseDate: Date = new Date()
+  ): Promise<TaskForecastDate[]> {
+    const [tasks, settings, holidays] = await Promise.all([
+      this.wbsQueryRepository.getWbsTasks(wbsId),
+      this.systemSettingsRepository.get(),
+      this.companyHolidayRepository.findAll(),
+    ]);
+    const calendar = new CompanyCalendar(
+      settings.standardWorkingHours,
+      holidays
+    );
+
+    return tasks.map((task) => {
+      const forecast = ForecastCalculationService.calculateTaskForecast(
+        toForecastTaskInput(task),
+        options
+      );
+      const remainingHours = ForecastDateCalculationService.calculateRemainingHours(
+        forecast.forecastHours,
+        forecast.actualHours
+      );
+
+      // $queryRaw 由来で id が number になるため文字列に正規化する
+      const base: TaskForecastDate = {
+        taskId: String(task.id),
+        forecastHours: forecast.forecastHours,
+        actualHours: forecast.actualHours,
+        remainingHours,
+        forecastStartDate: null,
+        forecastEndDate: null,
+      };
+
+      // 実績未入力・完了タスクは見通しバーの対象外
+      if (!task.jissekiStart || task.status === 'COMPLETED') {
+        return base;
+      }
+
+      return {
+        ...base,
+        forecastStartDate: task.jissekiStart,
+        forecastEndDate: ForecastDateCalculationService.calculateForecastEndDate(
+          {
+            forecastHours: forecast.forecastHours,
+            actualHours: forecast.actualHours,
+            baseDate,
+          },
+          calendar
+        ),
+      };
+    });
   }
 
   async getForecastMethods() {

--- a/src/components/ganttv3/gantt-chart.tsx
+++ b/src/components/ganttv3/gantt-chart.tsx
@@ -237,11 +237,12 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
     // 行の寸法 - rowScale に比例（Ctrl+ホイールで均等に増減）
     const TASK_HEIGHT = Math.round(BASE_TASK_HEIGHT * rowScale);
     const ROW_SPACING = Math.round(BASE_ROW_SPACING * rowScale);
-    // 実績バー表示時は予定／実績の2本を縦に並べるため行高を拡張する
-    const ACTUAL_BAR_GAP = Math.max(2, Math.round(2 * rowScale));
-    const ROW_HEIGHT = style.showActual
-      ? TASK_HEIGHT * 2 + ACTUAL_BAR_GAP + ROW_SPACING
-      : TASK_HEIGHT + ROW_SPACING;
+    // 実績・見通しバー表示時は予定／実績／見通しを縦に並べるため行高を拡張する
+    const BAR_GAP = Math.max(2, Math.round(2 * rowScale));
+    const barsPerRow =
+      1 + (style.showActual ? 1 : 0) + (style.showForecast ? 1 : 0);
+    const ROW_HEIGHT =
+      TASK_HEIGHT * barsPerRow + BAR_GAP * (barsPerRow - 1) + ROW_SPACING;
     const CATEGORY_HEIGHT = Math.round(BASE_CATEGORY_HEIGHT * rowScale);
     const HEADER_HEIGHT = 50;
     const TASK_LIST_WIDTH = taskListWidth;
@@ -1245,17 +1246,25 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                         } else if (row.type === "task" && row.task) {
                           // タスクバー - タスクリスト行と完全に一致するY位置
                           const task = row.task;
-                          // 実績バー表示時は予定（上段）・実績（下段）を縦に並べる。
+                          // 実績・見通しバー表示時は予定（上段）・実績（中段）・見通し（下段）を縦に並べる。
                           // マイルストーンは1本扱いのため常に行中央に配置する。
                           const showActualBar =
                             style.showActual && !task.isMilestone;
-                          const blockHeight = showActualBar
-                            ? TASK_HEIGHT * 2 + ACTUAL_BAR_GAP
-                            : TASK_HEIGHT;
+                          const showForecastBar =
+                            style.showForecast && !task.isMilestone;
+                          const rowBars =
+                            1 +
+                            (showActualBar ? 1 : 0) +
+                            (showForecastBar ? 1 : 0);
+                          const blockHeight =
+                            TASK_HEIGHT * rowBars + BAR_GAP * (rowBars - 1);
                           const plannedBarY =
                             row.y + (row.height - blockHeight) / 2;
                           const actualBarY =
-                            plannedBarY + TASK_HEIGHT + ACTUAL_BAR_GAP;
+                            plannedBarY + TASK_HEIGHT + BAR_GAP;
+                          const forecastBarY =
+                            plannedBarY +
+                            (showActualBar ? 2 : 1) * (TASK_HEIGHT + BAR_GAP);
                           // ドラッグ中はプレビュー日付でバーを描画
                           const preview =
                             dragPreview && dragPreview.taskId === task.id
@@ -1297,6 +1306,44 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                             );
                           }
 
+                          // 見通しバー（見通し日付がある非マイルストーンのみ。
+                          // 実績未入力・完了タスクにはサーバー側で日付が付かない）
+                          let forecastBar: JSX.Element | null = null;
+                          if (
+                            showForecastBar &&
+                            task.forecastStartDate &&
+                            task.forecastEndDate
+                          ) {
+                            const forecastX = dateToX(task.forecastStartDate);
+                            const forecastEndX = dateToXEnd(
+                              task.forecastEndDate,
+                            );
+                            const forecastWidth = Math.max(
+                              forecastEndX - forecastX,
+                              20,
+                            );
+                            forecastBar = (
+                              <g
+                                key={`${row.id}-forecast`}
+                                data-testid="ganttv3-forecast-bar"
+                                style={{ pointerEvents: "none" }}
+                              >
+                                <rect
+                                  x={forecastX}
+                                  y={forecastBarY}
+                                  width={forecastWidth}
+                                  height={TASK_HEIGHT}
+                                  rx={4}
+                                  fill={task.color}
+                                  fillOpacity={0.2}
+                                  stroke={task.color}
+                                  strokeWidth={1}
+                                  strokeDasharray="4 2"
+                                />
+                              </g>
+                            );
+                          }
+
                           return (
                             <g key={row.id}>
                               <TaskBar
@@ -1326,6 +1373,7 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                                 }
                               />
                               {actualBar}
+                              {forecastBar}
                             </g>
                           );
                         }

--- a/src/components/ganttv3/gantt-v3-client.tsx
+++ b/src/components/ganttv3/gantt-v3-client.tsx
@@ -30,6 +30,7 @@ const defaultGanttStyle: GanttStyle = {
   showGrid: true,
   showProgress: true,
   showActual: false,
+  showForecast: false,
   showDependencies: true,
   showCriticalPath: true,
   showWeekends: true,

--- a/src/components/ganttv3/gantt.ts
+++ b/src/components/ganttv3/gantt.ts
@@ -8,6 +8,8 @@ export interface Task {
   duration: number; // 予定工数(時間)。暦日数ではない（実日程は startDate/endDate）
   actualStartDate?: Date; // 実績開始日
   actualEndDate?: Date; // 実績終了日（未完了で実績開始のみの場合は本日が入る）
+  forecastStartDate?: Date; // 見通し開始日（実績開始日と同じ。実績なし・完了タスクは未設定）
+  forecastEndDate?: Date; // 見通し終了日（残見通し工数を基準稼働時間で消化し終える営業日）
   color: string; // 色
   isMilestone: boolean; // マイルストーンかどうか
   progress: number; // 進捗（進捗測定方式で算出した実効値。表示用）
@@ -60,6 +62,7 @@ export interface GanttStyle {
   showGrid: boolean;
   showProgress: boolean;
   showActual: boolean; // 実績バー（予定の下段）の表示
+  showForecast: boolean; // 見通しバー（実績の下段）の表示
   showDependencies: boolean;
   showCriticalPath: boolean;
   showWeekends: boolean;

--- a/src/components/ganttv3/quick-actions.tsx
+++ b/src/components/ganttv3/quick-actions.tsx
@@ -24,6 +24,7 @@ import {
   Download,
   ArrowUpDown,
   BarChart3,
+  TrendingUp,
 } from "lucide-react";
 
 interface QuickActionsProps {
@@ -300,6 +301,22 @@ export const QuickActions = ({
         >
           <BarChart3 className="w-4 h-4" />
           実績
+        </Button>
+
+        <Button
+          variant={style.showForecast ? "default" : "outline"}
+          size="sm"
+          title="見通しバー表示（実績の下段に見通しを表示）"
+          className="gap-1"
+          onClick={() =>
+            onStyleChange({
+              ...style,
+              showForecast: !style.showForecast,
+            })
+          }
+        >
+          <TrendingUp className="w-4 h-4" />
+          見通し
         </Button>
       </div>
 

--- a/src/components/task-scheduling/scheduling-gantt-preview.tsx
+++ b/src/components/task-scheduling/scheduling-gantt-preview.tsx
@@ -23,6 +23,7 @@ const previewStyle: GanttStyle = {
   showGrid: true,
   showProgress: false,
   showActual: false,
+  showForecast: false,
   showDependencies: true,
   showCriticalPath: false,
   showWeekends: true,

--- a/src/domains/forecast/forecast-date-calculation-service.ts
+++ b/src/domains/forecast/forecast-date-calculation-service.ts
@@ -1,0 +1,74 @@
+/**
+ * 見通し日付計算サービス
+ * 残り見通し工数（見通し工数 − 実績工数）を基準稼働時間/日で
+ * 営業日ごとに消化する想定で、見通し終了日を算出する。
+ * 見通し工数自体の算出は ForecastCalculationService（docs/specs/03-forecast-calculation.md）が担う。
+ */
+
+import { addDays, startOfDay } from "date-fns";
+import { CompanyCalendar } from "@/domains/calendar/company-calendar";
+
+export interface ForecastEndDateInput {
+  /** 見通し工数（時間） */
+  forecastHours: number;
+  /** 実績工数（時間） */
+  actualHours: number;
+  /** 消化を開始する基準日（通常は「今日」）。時刻成分は無視する */
+  baseDate: Date;
+}
+
+export class ForecastDateCalculationService {
+  /** 終了日探索の上限日数（異常データによる無限ループ防止） */
+  static readonly MAX_LOOKAHEAD_DAYS = 3650;
+
+  /**
+   * 残り見通し工数を算出する
+   */
+  static calculateRemainingHours(
+    forecastHours: number,
+    actualHours: number
+  ): number {
+    return Math.max(0, forecastHours - actualHours);
+  }
+
+  /**
+   * 見通し終了日を算出する
+   * @param input 見通し工数・実績工数・基準日
+   * @param calendar 会社カレンダー（営業日判定・基準稼働時間）
+   * @returns 残工数を消化し終える営業日。残工数が0以下の場合は null
+   * @description
+   * 基準日から1日ずつ進め、営業日ごとに基準稼働時間分を消化し、
+   * 残工数が尽きた営業日を終了日として返す。基準日が営業日なら当日から消化する。
+   * MAX_LOOKAHEAD_DAYS を超える場合は最後に消化した営業日で打ち切る。
+   */
+  static calculateForecastEndDate(
+    input: ForecastEndDateInput,
+    calendar: CompanyCalendar
+  ): Date | null {
+    let remaining = this.calculateRemainingHours(
+      input.forecastHours,
+      input.actualHours
+    );
+    if (remaining <= 0) {
+      return null;
+    }
+
+    const hoursPerDay = calendar.getStandardWorkingHours();
+    let current = startOfDay(input.baseDate);
+    let lastBusinessDay: Date | null = null;
+
+    for (let i = 0; i <= ForecastDateCalculationService.MAX_LOOKAHEAD_DAYS; i++) {
+      if (!calendar.isCompanyHoliday(current)) {
+        remaining -= hoursPerDay;
+        lastBusinessDay = current;
+        if (remaining <= 0) {
+          return current;
+        }
+      }
+      current = addDays(current, 1);
+    }
+
+    // 上限到達時は最後に消化した営業日で打ち切る
+    return lastBusinessDay;
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements forecast end date calculation functionality to display forecast bars on the gantt chart. It adds a new domain service for calculating when tasks will complete based on remaining work hours, integrates it into the application layer, and updates the gantt chart UI to render forecast bars alongside actual bars.

## Key Changes

- **New Domain Service**: `ForecastDateCalculationService` calculates forecast end dates by consuming remaining work hours (forecast hours - actual hours) at a configurable daily rate, accounting for weekends and company holidays
- **Application Service Enhancement**: `ForecastApplicationService.calculateTasksForecastDates()` orchestrates forecast date calculation for all tasks in a WBS, fetching system settings and company holidays once to avoid N+1 queries
- **Gantt Chart UI Updates**:
  - Added `showForecast` style toggle to display/hide forecast bars
  - Forecast bars render as dashed rectangles below actual bars (or below planned bars if actual is hidden)
  - Updated row height calculation to accommodate up to 3 bars per row (planned/actual/forecast)
  - Added "見通し" (Forecast) button to quick actions toolbar
- **Server Action Integration**: `getGanttTasks()` now fetches forecast dates and attaches them to gantt tasks, using project settings to determine the forecast calculation method
- **Comprehensive Test Coverage**:
  - Domain service tests covering business day calculation, holiday handling, edge cases (zero remaining hours, large values, base date on weekends)
  - Application service tests verifying N+1 prevention, options propagation, system settings integration, and task ID normalization

## Implementation Details

- Forecast bars only appear for tasks with actual start dates and positive remaining hours (completed tasks and not-started tasks show no forecast)
- Forecast start date matches the task's actual start date for visual alignment
- The calculation respects both Japanese national holidays and company-specific holidays via `CompanyCalendar`
- Remaining hours are calculated as `max(0, forecastHours - actualHours)` to handle edge cases
- A `MAX_LOOKAHEAD_DAYS` cap (3650 days) prevents infinite loops on anomalous data
- Task IDs are normalized to strings since `$queryRaw` may return numbers

https://claude.ai/code/session_01Xdy1T51acbtvtHLnquMbAK