### PR TITLE
Add progress line (inazuma) visualization and task management features

### DIFF
--- a/src/__tests__/components/ganttv3/GanttChart.test.tsx
+++ b/src/__tests__/components/ganttv3/GanttChart.test.tsx
@@ -600,6 +600,98 @@ describe("GanttChart", () => {
         expect.objectContaining({ id: "1", duration: 16 }),
       );
     });
+
+    it("onDeleteTask未指定では削除ボタンを表示しない", () => {
+      const { container } = render(<GanttChart {...defaultProps} editMode />);
+      mouseDownOnBar(container, "1", 100);
+      fireEvent.mouseUp(document);
+      expect(screen.queryByText("削除")).not.toBeInTheDocument();
+    });
+
+    it("パネルの削除ボタンで onDeleteTask(taskId) が発火しパネルが閉じる", () => {
+      const onDeleteTask = jest.fn();
+      const { container } = render(
+        <GanttChart {...defaultProps} editMode onDeleteTask={onDeleteTask} />,
+      );
+
+      mouseDownOnBar(container, "1", 100);
+      fireEvent.mouseUp(document);
+      expect(screen.getByText("削除")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("削除"));
+
+      expect(onDeleteTask).toHaveBeenCalledWith("1");
+      expect(screen.queryByText("予定開始日")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("色分けモード", () => {
+    const coloredTask = [
+      makeTask({
+        id: "1",
+        name: "タスクA",
+        category: "設計",
+        color: "#123456",
+        startDate: new Date("2024-01-01T00:00:00.000Z"),
+        endDate: new Date("2024-01-03T00:00:00.000Z"),
+        actualStartDate: new Date("2024-01-02T00:00:00.000Z"),
+        actualEndDate: new Date("2024-01-04T00:00:00.000Z"),
+        forecastStartDate: new Date("2024-01-02T00:00:00.000Z"),
+        forecastEndDate: new Date("2024-01-08T00:00:00.000Z"),
+      }),
+    ];
+
+    it("phase モード（既定）ではフェーズ色（task.color）がそのまま使われる", () => {
+      const { container } = render(
+        <GanttChart
+          {...defaultProps}
+          tasks={coloredTask}
+          style={makeStyle({
+            showDependencies: false,
+            showTodayLine: false,
+            showActual: true,
+            showForecast: true,
+            colorMode: "phase",
+          })}
+        />,
+      );
+      const bar = container.querySelector('[data-task-id="1"] rect')!;
+      expect(bar.getAttribute("fill")).toBe("#12345620");
+      const actualRect = container.querySelector(
+        '[data-testid="ganttv3-actual-bar"] rect',
+      )!;
+      expect(actualRect.getAttribute("fill")).toBe("#123456");
+      const forecastRect = container.querySelector(
+        '[data-testid="ganttv3-forecast-bar"] rect',
+      )!;
+      expect(forecastRect.getAttribute("fill")).toBe("#123456");
+    });
+
+    it("planActualForecast モードでは予定/実績/見通しごとに固定色になる", () => {
+      const { container } = render(
+        <GanttChart
+          {...defaultProps}
+          tasks={coloredTask}
+          style={makeStyle({
+            showDependencies: false,
+            showTodayLine: false,
+            showActual: true,
+            showForecast: true,
+            colorMode: "planActualForecast",
+          })}
+        />,
+      );
+      const bar = container.querySelector('[data-task-id="1"] rect')!;
+      expect(bar.getAttribute("fill")).toBe("#3B82F620"); // 予定=固定の青
+      const actualRect = container.querySelector(
+        '[data-testid="ganttv3-actual-bar"] rect',
+      )!;
+      expect(actualRect.getAttribute("fill")).toBe("#10B981"); // 実績=固定の緑
+      const forecastRect = container.querySelector(
+        '[data-testid="ganttv3-forecast-bar"] rect',
+      )!;
+      expect(forecastRect.getAttribute("fill")).toBe("#F59E0B"); // 見通し=固定の橙
+    });
   });
 
   describe("バー内ラベル（inside 配置）", () => {

--- a/src/__tests__/components/ganttv3/GanttChart.test.tsx
+++ b/src/__tests__/components/ganttv3/GanttChart.test.tsx
@@ -159,6 +159,50 @@ describe("GanttChart", () => {
     });
   });
 
+  describe("イナズマ線（進捗線）", () => {
+    const DAY = 24 * 60 * 60 * 1000;
+    // 基準日(今日)がタイムライン範囲内に入るよう、実行時の現在日を跨ぐ期間にする
+    const now = new Date();
+    const inazumaTasks = [
+      makeTask({
+        id: "1",
+        name: "タスクA",
+        category: "設計",
+        startDate: new Date(now.getTime() - 5 * DAY),
+        endDate: new Date(now.getTime() + 5 * DAY),
+        progress: 30,
+      }),
+    ];
+
+    it("showProgressLine ON でイナズマ線を描画する", () => {
+      const { queryByTestId } = render(
+        <GanttChart
+          {...defaultProps}
+          tasks={inazumaTasks}
+          style={makeStyle({
+            showDependencies: false,
+            showProgressLine: true,
+          })}
+        />,
+      );
+      expect(queryByTestId("ganttv3-progress-line")).toBeInTheDocument();
+    });
+
+    it("showProgressLine OFF ではイナズマ線を描画しない", () => {
+      const { queryByTestId } = render(
+        <GanttChart
+          {...defaultProps}
+          tasks={inazumaTasks}
+          style={makeStyle({
+            showDependencies: false,
+            showProgressLine: false,
+          })}
+        />,
+      );
+      expect(queryByTestId("ganttv3-progress-line")).not.toBeInTheDocument();
+    });
+  });
+
   describe("ズーム操作", () => {
     it("ズームイン/アウトで onZoomChange が 1.2倍/÷1.2 で発火", () => {
       const onZoomChange = jest.fn();

--- a/src/__tests__/components/ganttv3/InlineTaskEditPanel.test.tsx
+++ b/src/__tests__/components/ganttv3/InlineTaskEditPanel.test.tsx
@@ -8,7 +8,7 @@ const assignees = [
   { id: 2, name: "鈴木" },
 ];
 
-function setup(taskOverrides = {}) {
+function setup(taskOverrides = {}, extraProps = {}) {
   const onChange = jest.fn();
   const onClose = jest.fn();
   const onEditDependencies = jest.fn();
@@ -28,6 +28,7 @@ function setup(taskOverrides = {}) {
       onChange={onChange}
       onEditDependencies={onEditDependencies}
       onClose={onClose}
+      {...extraProps}
     />,
   );
   return { onChange, onClose, onEditDependencies, task };
@@ -110,5 +111,17 @@ describe("InlineTaskEditPanel", () => {
     expect(screen.queryByText("予定終了日")).not.toBeInTheDocument();
     expect(screen.queryByText("予定工数(h)")).not.toBeInTheDocument();
     expect(screen.queryByText("担当者")).not.toBeInTheDocument();
+  });
+
+  it("onDelete未指定では削除ボタンを表示しない", () => {
+    setup();
+    expect(screen.queryByText("削除")).not.toBeInTheDocument();
+  });
+
+  it("onDelete指定時は削除ボタンを表示し、クリックで発火する", () => {
+    const onDelete = jest.fn();
+    setup({}, { onDelete });
+    fireEvent.click(screen.getByText("削除"));
+    expect(onDelete).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/components/ganttv3/ProgressLine.test.tsx
+++ b/src/__tests__/components/ganttv3/ProgressLine.test.tsx
@@ -59,7 +59,7 @@ describe("ProgressLine", () => {
     expect(container.querySelectorAll("circle")).toHaveLength(2);
   });
 
-  it("基準日がタイムライン範囲外なら何も描画しない", () => {
+  it("基準日がタイムライン終了より後なら何も描画しない", () => {
     const { queryByTestId } = renderInSvg(
       <ProgressLine
         tasks={[makeTask({ id: "1" })]}
@@ -71,6 +71,48 @@ describe("ProgressLine", () => {
         bottomY={100}
         color="#DB2777"
         today={new Date("2024-03-01T00:00:00.000Z")}
+      />,
+    );
+    expect(queryByTestId("ganttv3-progress-line")).not.toBeInTheDocument();
+  });
+
+  it("基準日がタイムライン開始より前なら何も描画しない", () => {
+    const { queryByTestId } = renderInSvg(
+      <ProgressLine
+        tasks={[makeTask({ id: "1" })]}
+        centerYById={new Map([["1", 10]])}
+        dateToX={dateToX}
+        timelineStart={timelineStart}
+        timelineEnd={timelineEnd}
+        topY={0}
+        bottomY={100}
+        color="#DB2777"
+        today={new Date("2023-12-01T00:00:00.000Z")}
+      />,
+    );
+    expect(queryByTestId("ganttv3-progress-line")).not.toBeInTheDocument();
+  });
+
+  it("進捗点が1つも無い（全てマイルストーン）場合は縦線を描画しない", () => {
+    const tasks = [
+      makeTask({ id: "1", isMilestone: true }),
+      makeTask({ id: "2", isMilestone: true }),
+    ];
+    const centerYById = new Map([
+      ["1", 10],
+      ["2", 30],
+    ]);
+    const { queryByTestId } = renderInSvg(
+      <ProgressLine
+        tasks={tasks}
+        centerYById={centerYById}
+        dateToX={dateToX}
+        timelineStart={timelineStart}
+        timelineEnd={timelineEnd}
+        topY={0}
+        bottomY={100}
+        color="#DB2777"
+        today={today}
       />,
     );
     expect(queryByTestId("ganttv3-progress-line")).not.toBeInTheDocument();

--- a/src/__tests__/components/ganttv3/ProgressLine.test.tsx
+++ b/src/__tests__/components/ganttv3/ProgressLine.test.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ProgressLine } from "@/components/ganttv3/progress-line";
+import { makeTask } from "./_fixtures";
+
+const DAY = 24 * 60 * 60 * 1000;
+const dateToX = (d: Date): number => d.getTime() / DAY;
+
+function renderInSvg(ui: React.ReactElement) {
+  return render(<svg>{ui}</svg>);
+}
+
+const timelineStart = new Date("2024-01-01T00:00:00.000Z");
+const timelineEnd = new Date("2024-02-01T00:00:00.000Z");
+const today = new Date("2024-01-10T00:00:00.000Z");
+
+describe("ProgressLine", () => {
+  it("進捗点を通る polyline と頂点ドットを描画する", () => {
+    const tasks = [
+      makeTask({
+        id: "1",
+        startDate: new Date("2024-01-01T00:00:00.000Z"),
+        endDate: new Date("2024-01-11T00:00:00.000Z"),
+        progress: 50,
+      }),
+      makeTask({
+        id: "2",
+        startDate: new Date("2024-01-01T00:00:00.000Z"),
+        endDate: new Date("2024-01-11T00:00:00.000Z"),
+        progress: 100,
+      }),
+    ];
+    const centerYById = new Map([
+      ["1", 10],
+      ["2", 30],
+    ]);
+    const { container, getByTestId } = renderInSvg(
+      <ProgressLine
+        tasks={tasks}
+        centerYById={centerYById}
+        dateToX={dateToX}
+        timelineStart={timelineStart}
+        timelineEnd={timelineEnd}
+        topY={0}
+        bottomY={100}
+        color="#DB2777"
+        today={today}
+      />,
+    );
+
+    expect(getByTestId("ganttv3-progress-line")).toBeInTheDocument();
+    const polyline = container.querySelector("polyline")!;
+    expect(polyline).toBeInTheDocument();
+    expect(polyline).toHaveAttribute("stroke", "#DB2777");
+    // 端点2 + タスク2 = 4頂点
+    expect(polyline.getAttribute("points")!.trim().split(" ")).toHaveLength(4);
+    // 頂点ドットは端点を除くタスク2点
+    expect(container.querySelectorAll("circle")).toHaveLength(2);
+  });
+
+  it("基準日がタイムライン範囲外なら何も描画しない", () => {
+    const { queryByTestId } = renderInSvg(
+      <ProgressLine
+        tasks={[makeTask({ id: "1" })]}
+        centerYById={new Map([["1", 10]])}
+        dateToX={dateToX}
+        timelineStart={timelineStart}
+        timelineEnd={timelineEnd}
+        topY={0}
+        bottomY={100}
+        color="#DB2777"
+        today={new Date("2024-03-01T00:00:00.000Z")}
+      />,
+    );
+    expect(queryByTestId("ganttv3-progress-line")).not.toBeInTheDocument();
+  });
+
+  it("centerY 未登録のタスクはスキップする", () => {
+    const tasks = [
+      makeTask({
+        id: "1",
+        startDate: new Date("2024-01-01T00:00:00.000Z"),
+        endDate: new Date("2024-01-11T00:00:00.000Z"),
+        progress: 50,
+      }),
+      makeTask({ id: "missing" }),
+    ];
+    const centerYById = new Map([["1", 10]]);
+    const { container } = renderInSvg(
+      <ProgressLine
+        tasks={tasks}
+        centerYById={centerYById}
+        dateToX={dateToX}
+        timelineStart={timelineStart}
+        timelineEnd={timelineEnd}
+        topY={0}
+        bottomY={100}
+        color="#DB2777"
+        today={today}
+      />,
+    );
+    // 端点2 + タスク1 = 3頂点、ドットは1
+    expect(
+      container.querySelector("polyline")!.getAttribute("points")!.trim().split(" "),
+    ).toHaveLength(3);
+    expect(container.querySelectorAll("circle")).toHaveLength(1);
+  });
+});

--- a/src/__tests__/components/ganttv3/QuickActions.test.tsx
+++ b/src/__tests__/components/ganttv3/QuickActions.test.tsx
@@ -64,6 +64,7 @@ describe("QuickActions", () => {
     ["依存関係表示", "showDependencies"],
     ["クリティカルパス表示", "showCriticalPath"],
     ["本日ライン表示", "showTodayLine"],
+    ["イナズマ線（進捗線）表示", "showProgressLine"],
     ["実績バー表示（予定の下段に実績を表示）", "showActual"],
     ["見通しバー表示（実績の下段に見通しを表示）", "showForecast"],
   ] as const)("%s ボタンで %s がトグルされる", (label, flag) => {

--- a/src/__tests__/components/ganttv3/QuickActions.test.tsx
+++ b/src/__tests__/components/ganttv3/QuickActions.test.tsx
@@ -25,25 +25,37 @@ const baseProps = {
 beforeEach(() => jest.clearAllMocks());
 
 describe("QuickActions", () => {
+  it("操作ボタンはアイコンのみ（アクセシブルネーム/ツールチップでボタン名を示す）", () => {
+    render(<QuickActions {...baseProps} />);
+    const addButton = screen.getByRole("button", { name: "タスク追加" });
+    expect(addButton).toBeInTheDocument();
+    // ボタン内にテキストラベルは無い（アイコンのみ）
+    expect(addButton).toHaveTextContent("");
+  });
+
   it("タスク追加ボタンで onAddTask が発火", () => {
     render(<QuickActions {...baseProps} />);
-    fireEvent.click(screen.getByText("🚧タスク追加"));
+    fireEvent.click(screen.getByRole("button", { name: "タスク追加" }));
     expect(baseProps.onAddTask).toHaveBeenCalled();
   });
 
   it("選択タスクなしでは複製・削除ボタンを表示しない", () => {
     render(<QuickActions {...baseProps} />);
-    expect(screen.queryByText(/複製/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/削除/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /複製/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /削除/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("選択タスクありでは件数付きの複製・削除ボタンを表示し、クリックで発火", () => {
     render(
       <QuickActions {...baseProps} selectedTasks={new Set(["1", "2"])} />,
     );
-    fireEvent.click(screen.getByText("複製 (2)"));
+    fireEvent.click(screen.getByRole("button", { name: "複製（2件）" }));
     expect(baseProps.onDuplicateTasks).toHaveBeenCalled();
-    fireEvent.click(screen.getByText("削除 (2)"));
+    fireEvent.click(screen.getByRole("button", { name: "削除（2件）" }));
     expect(baseProps.onDeleteTasks).toHaveBeenCalled();
   });
 
@@ -54,38 +66,73 @@ describe("QuickActions", () => {
     ["本日ライン表示", "showTodayLine"],
     ["実績バー表示（予定の下段に実績を表示）", "showActual"],
     ["見通しバー表示（実績の下段に見通しを表示）", "showForecast"],
-  ] as const)("%s ボタンで %s がトグルされる", (title, flag) => {
+  ] as const)("%s ボタンで %s がトグルされる", (label, flag) => {
     const style = makeStyle();
     render(<QuickActions {...baseProps} style={style} />);
-    fireEvent.click(screen.getByTitle(title));
+    fireEvent.click(screen.getByRole("button", { name: label }));
     expect(baseProps.onStyleChange).toHaveBeenCalledWith({
       ...style,
       [flag]: !style[flag],
     });
   });
 
-  it("taskOpsDisabled のとき追加・複製・削除が無効化される", () => {
+  it("addDisabled のときタスク追加が無効化される", () => {
+    render(<QuickActions {...baseProps} addDisabled />);
+    expect(screen.getByRole("button", { name: "タスク追加" })).toBeDisabled();
+  });
+
+  it("無効化時もツールチップが開けるよう、ボタンをフォーカス可能な span で包む（disabled要素はhover/focusイベントを発火しないため）", () => {
+    const { rerender } = render(<QuickActions {...baseProps} addDisabled />);
+    const disabledButton = screen.getByRole("button", { name: "タスク追加" });
+    expect(disabledButton.parentElement).toHaveAttribute("tabIndex", "0");
+
+    rerender(<QuickActions {...baseProps} addDisabled={false} />);
+    const enabledButton = screen.getByRole("button", { name: "タスク追加" });
+    expect(enabledButton.parentElement).toHaveAttribute("tabIndex", "-1");
+  });
+
+  it("duplicateDisabled/deleteDisabled でそれぞれ独立して無効化される", () => {
     render(
       <QuickActions
         {...baseProps}
         selectedTasks={new Set(["1"])}
-        taskOpsDisabled
+        duplicateDisabled
+        deleteDisabled={false}
       />,
     );
-    expect(screen.getByText("🚧タスク追加").closest("button")).toBeDisabled();
-    expect(screen.getByText(/複製/).closest("button")).toBeDisabled();
-    expect(screen.getByText(/削除/).closest("button")).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "複製（1件）" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "削除（1件）" }),
+    ).not.toBeDisabled();
+  });
+
+  it("色分けモード切替ボタンで onStyleChange に colorMode が渡る", () => {
+    const style = makeStyle({ colorMode: "phase" });
+    render(<QuickActions {...baseProps} style={style} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "予定・実績・見通しで色分け" }),
+    );
+    expect(baseProps.onStyleChange).toHaveBeenCalledWith({
+      ...style,
+      colorMode: "planActualForecast",
+    });
   });
 
   it("onExportTsv 未指定なら TSV出力ボタンは表示しない", () => {
     render(<QuickActions {...baseProps} />);
-    expect(screen.queryByText("TSV出力")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "タスク一覧をTSVで出力" }),
+    ).not.toBeInTheDocument();
   });
 
   it("onExportTsv 指定時は TSV出力ボタンを表示し、クリックで発火", () => {
     const onExportTsv = jest.fn();
     render(<QuickActions {...baseProps} onExportTsv={onExportTsv} />);
-    fireEvent.click(screen.getByText("TSV出力"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "タスク一覧をTSVで出力" }),
+    );
     expect(onExportTsv).toHaveBeenCalled();
   });
 

--- a/src/__tests__/components/ganttv3/TaskBar.test.tsx
+++ b/src/__tests__/components/ganttv3/TaskBar.test.tsx
@@ -70,6 +70,28 @@ describe("TaskBar", () => {
     ).toBeInTheDocument();
   });
 
+  it("barColor 指定時は task.color より優先して使われる", () => {
+    const task = makeTask({ id: "1", color: "#000000" });
+    const { container } = renderInSvg(
+      <TaskBar {...baseProps} task={task} barColor="#3B82F6" style={makeStyle()} />,
+    );
+    expect(container.querySelector("rect")).toHaveAttribute(
+      "fill",
+      "#3B82F620",
+    );
+  });
+
+  it("barColor 未指定では task.color が使われる", () => {
+    const task = makeTask({ id: "1", color: "#123456" });
+    const { container } = renderInSvg(
+      <TaskBar {...baseProps} task={task} style={makeStyle()} />,
+    );
+    expect(container.querySelector("rect")).toHaveAttribute(
+      "fill",
+      "#12345620",
+    );
+  });
+
   it("data-task-id 属性を持つ（E2E用フック）", () => {
     const { container } = renderInSvg(
       <TaskBar {...baseProps} task={makeTask({ id: "task-9" })} style={makeStyle()} />,

--- a/src/__tests__/components/ganttv3/TaskDetailSidebar.test.tsx
+++ b/src/__tests__/components/ganttv3/TaskDetailSidebar.test.tsx
@@ -35,7 +35,9 @@ describe("TaskDetailSidebar", () => {
       startDate: new Date(2024, 0, 1),
       endDate: new Date(2024, 0, 3),
       actualStartDate: new Date(2024, 0, 2),
+      actualDuration: 12.34,
       forecastEndDate: new Date(2024, 0, 8),
+      forecastDuration: 20,
       description: "レビュー観点の説明",
     });
     render(
@@ -54,6 +56,10 @@ describe("TaskDetailSidebar", () => {
     expect(screen.getByText("8h")).toBeInTheDocument();
     expect(screen.getByText("2024/01/02")).toBeInTheDocument(); // 実績開始
     expect(screen.getByText("2024/01/08")).toBeInTheDocument(); // 見通し終了
+    expect(screen.getByText("実績工数")).toBeInTheDocument();
+    expect(screen.getByText("12.3h")).toBeInTheDocument(); // 実績工数（小数第1位に丸め）
+    expect(screen.getByText("見通し工数")).toBeInTheDocument();
+    expect(screen.getByText("20h")).toBeInTheDocument();
     expect(screen.getByText("レビュー観点の説明")).toBeInTheDocument();
   });
 

--- a/src/__tests__/components/ganttv3/TaskListRow.test.tsx
+++ b/src/__tests__/components/ganttv3/TaskListRow.test.tsx
@@ -32,4 +32,13 @@ describe("TaskListRow", () => {
     expect(row.style.top).toBe("40px");
     expect(row.style.height).toBe("24px");
   });
+
+  it("barColor 指定時は先頭ドットの色に使われる（task.colorより優先）", () => {
+    const task = makeTask({ id: "1", name: "T", color: "#000000" });
+    const { container } = render(
+      <TaskListRow task={task} top={0} height={20} barColor="#3B82F6" />,
+    );
+    const dot = container.querySelector(".w-2.h-2");
+    expect(dot).toHaveStyle({ backgroundColor: "#3B82F6" });
+  });
 });

--- a/src/__tests__/components/ganttv3/_fixtures.ts
+++ b/src/__tests__/components/ganttv3/_fixtures.ts
@@ -46,6 +46,7 @@ export function makeStyle(overrides: Partial<GanttStyle> = {}): GanttStyle {
     showProgress: true,
     showActual: false,
     showForecast: false,
+    colorMode: "phase",
     showDependencies: true,
     showCriticalPath: true,
     showWeekends: true,

--- a/src/__tests__/components/ganttv3/_fixtures.ts
+++ b/src/__tests__/components/ganttv3/_fixtures.ts
@@ -51,6 +51,7 @@ export function makeStyle(overrides: Partial<GanttStyle> = {}): GanttStyle {
     showCriticalPath: true,
     showWeekends: true,
     showTodayLine: true,
+    showProgressLine: false,
     taskHeight: 20,
     rowSpacing: 8,
     labelPosition: "outside",
@@ -62,6 +63,7 @@ export function makeStyle(overrides: Partial<GanttStyle> = {}): GanttStyle {
       criticalPath: "#DC2626",
       weekend: "#F3F4F6",
       today: "#10B981",
+      progressLine: "#DB2777",
     },
     ...overrides,
   };

--- a/src/__tests__/components/ganttv3/phaseColors.test.ts
+++ b/src/__tests__/components/ganttv3/phaseColors.test.ts
@@ -1,6 +1,8 @@
 import {
   PHASE_COLOR_PALETTE,
+  PLAN_ACTUAL_FORECAST_COLORS,
   phaseColor,
+  resolveBarColor,
 } from "@/components/ganttv3/utils/phase-colors";
 
 describe("phaseColor", () => {
@@ -19,5 +21,40 @@ describe("phaseColor", () => {
     PHASE_COLOR_PALETTE.forEach((c) => {
       expect(c).toMatch(/^#[0-9a-f]{6}$/);
     });
+  });
+});
+
+describe("resolveBarColor", () => {
+  const task = { color: "#123456", isMilestone: false };
+
+  it("phase モードでは task.color をそのまま返す", () => {
+    expect(resolveBarColor(task, "phase", "planned")).toBe("#123456");
+    expect(resolveBarColor(task, "phase", "actual")).toBe("#123456");
+    expect(resolveBarColor(task, "phase", "forecast")).toBe("#123456");
+  });
+
+  it("planActualForecast モードでは種別ごとの固定色を返す", () => {
+    expect(resolveBarColor(task, "planActualForecast", "planned")).toBe(
+      PLAN_ACTUAL_FORECAST_COLORS.planned,
+    );
+    expect(resolveBarColor(task, "planActualForecast", "actual")).toBe(
+      PLAN_ACTUAL_FORECAST_COLORS.actual,
+    );
+    expect(resolveBarColor(task, "planActualForecast", "forecast")).toBe(
+      PLAN_ACTUAL_FORECAST_COLORS.forecast,
+    );
+  });
+
+  it("マイルストーンは色分けモードに関わらず常に task.color", () => {
+    const milestone = { color: "#EF4444", isMilestone: true };
+    expect(resolveBarColor(milestone, "planActualForecast", "planned")).toBe(
+      "#EF4444",
+    );
+  });
+
+  it("barType 省略時は既定で planned として解決する", () => {
+    expect(resolveBarColor(task, "planActualForecast")).toBe(
+      PLAN_ACTUAL_FORECAST_COLORS.planned,
+    );
   });
 });

--- a/src/__tests__/components/ganttv3/progressLine.test.ts
+++ b/src/__tests__/components/ganttv3/progressLine.test.ts
@@ -86,6 +86,11 @@ describe("progressPointX", () => {
     expect(progressPointX(t, todayMs, todayX, dateToX)).toBeNull();
   });
 
+  it("非有限な進捗率（NaN）は進捗点を持たない（null）", () => {
+    const t = task("2024-01-01", "2024-01-11", Number.NaN);
+    expect(progressPointX(t, todayMs, todayX, dateToX)).toBeNull();
+  });
+
   it("進捗率は0-100にクランプされる", () => {
     const over = task("2024-01-01", "2024-01-11", 150);
     const under = task("2024-01-01", "2024-01-11", -20);
@@ -127,6 +132,25 @@ describe("buildProgressLinePoints", () => {
     expect(points[1].x).toBeLessThan(todayX);
     expect(points[2].y).toBe(30);
     expect(points[2].x).toBeGreaterThan(todayX);
+  });
+
+  it("有効な行の間にスキップ行が挟まっても、両端の有効点のみを通る", () => {
+    const rows = [
+      rowOf(task("2024-01-01", "2024-01-11", 50), 10), // 有効
+      rowOf(task("2024-01-10", "2024-01-10", 0, true), 20), // マイルストーン→スキップ
+      rowOf(task("2024-01-01", "2024-01-11", 100), 30), // 有効
+    ];
+    const points = buildProgressLinePoints(
+      rows,
+      todayMs,
+      todayX,
+      dateToX,
+      0,
+      100,
+    );
+    // 端点2 + 有効タスク2 = 4頂点。スキップ行のY(20)は通らない。
+    expect(points).toHaveLength(4);
+    expect(points.map((p) => p.y)).toEqual([0, 10, 30, 100]);
   });
 
   it("マイルストーン/ゼロ期間の行はスキップする（端点のみ残る）", () => {

--- a/src/__tests__/components/ganttv3/progressLine.test.ts
+++ b/src/__tests__/components/ganttv3/progressLine.test.ts
@@ -1,0 +1,159 @@
+import {
+  progressPointX,
+  buildProgressLinePoints,
+  type ProgressLineTask,
+  type ProgressLineRow,
+} from "@/components/ganttv3/utils/progressLine";
+
+// テスト用の線形 dateToX: エポック日数をそのままX(px)にする（1日=1px）
+const DAY = 24 * 60 * 60 * 1000;
+const dateToX = (d: Date): number => d.getTime() / DAY;
+
+function task(
+  startYmd: string,
+  endYmd: string,
+  progress: number,
+  isMilestone = false,
+): ProgressLineTask {
+  return {
+    startDate: new Date(`${startYmd}T00:00:00.000Z`),
+    endDate: new Date(`${endYmd}T00:00:00.000Z`),
+    progress,
+    isMilestone,
+  };
+}
+
+const todayMs = new Date("2024-01-10T00:00:00.000Z").getTime();
+const todayX = dateToX(new Date(todayMs));
+
+describe("progressPointX", () => {
+  it("進行中タスクが予定通りの進捗なら基準線(todayX)上に乗る", () => {
+    // 1/1〜1/11(10日)。1/10時点の予定進捗は 9/10=90%。実績90%なら達成日=1/10=基準日。
+    const t = task("2024-01-01", "2024-01-11", 90);
+    expect(progressPointX(t, todayMs, todayX, dateToX)).toBeCloseTo(todayX, 6);
+  });
+
+  it("進行中で遅れているタスクは基準線より左（X<todayX）へ張り出す", () => {
+    // 1/1〜1/11、実績50% → 達成日=1/6。基準日1/10より過去なので左。
+    const t = task("2024-01-01", "2024-01-11", 50);
+    const x = progressPointX(t, todayMs, todayX, dateToX)!;
+    expect(x).toBeLessThan(todayX);
+    // 達成日1/6 と 基準日1/10 の差 = -4px
+    expect(x).toBeCloseTo(todayX - 4, 6);
+  });
+
+  it("進行中で進んでいるタスクは基準線より右（X>todayX）へ張り出す", () => {
+    // 1/1〜1/11、実績100%（前倒し完了）→ 達成日=1/11。基準日1/10より未来なので右。
+    const t = task("2024-01-01", "2024-01-11", 100);
+    const x = progressPointX(t, todayMs, todayX, dateToX)!;
+    expect(x).toBeGreaterThan(todayX);
+    expect(x).toBeCloseTo(todayX + 1, 6);
+  });
+
+  it("未着手の将来タスク(0%)は基準線上に乗る（右へ誤って張り出さない）", () => {
+    // 1/20〜1/30、0%。基準日1/10はタスク開始前 → 基準点は開始日にクランプ、達成日=開始日 → 偏差0。
+    const t = task("2024-01-20", "2024-01-30", 0);
+    expect(progressPointX(t, todayMs, todayX, dateToX)).toBeCloseTo(todayX, 6);
+  });
+
+  it("完了済みの過去タスク(100%)は基準線上に乗る（左へ誤って張り出さない）", () => {
+    // 1/1〜1/5、100%。基準日1/10はタスク終了後 → 基準点は終了日にクランプ、達成日=終了日 → 偏差0。
+    const t = task("2024-01-01", "2024-01-05", 100);
+    expect(progressPointX(t, todayMs, todayX, dateToX)).toBeCloseTo(todayX, 6);
+  });
+
+  it("将来タスクを前倒し着手していれば右へ張り出す", () => {
+    // 1/20〜1/30(10日)、実績30% → 達成日=1/23。基準点=開始日1/20 → 偏差 +3px。
+    const t = task("2024-01-20", "2024-01-30", 30);
+    const x = progressPointX(t, todayMs, todayX, dateToX)!;
+    expect(x).toBeCloseTo(todayX + 3, 6);
+  });
+
+  it("期限超過で未完了の過去タスクは左へ張り出す", () => {
+    // 1/1〜1/5(4日)、実績50% → 達成日=1/3。基準点=終了日1/5 → 偏差 -2px。
+    const t = task("2024-01-01", "2024-01-05", 50);
+    const x = progressPointX(t, todayMs, todayX, dateToX)!;
+    expect(x).toBeCloseTo(todayX - 2, 6);
+  });
+
+  it("マイルストーンは進捗点を持たない（null）", () => {
+    const t = task("2024-01-10", "2024-01-10", 0, true);
+    expect(progressPointX(t, todayMs, todayX, dateToX)).toBeNull();
+  });
+
+  it("ゼロ期間（start===end）は進捗点を持たない（null）", () => {
+    const t = task("2024-01-10", "2024-01-10", 50);
+    expect(progressPointX(t, todayMs, todayX, dateToX)).toBeNull();
+  });
+
+  it("進捗率は0-100にクランプされる", () => {
+    const over = task("2024-01-01", "2024-01-11", 150);
+    const under = task("2024-01-01", "2024-01-11", -20);
+    // 150%→100%クランプ=達成日1/11、-20%→0%クランプ=達成日1/1
+    expect(progressPointX(over, todayMs, todayX, dateToX)).toBeCloseTo(
+      dateToX(new Date("2024-01-11T00:00:00.000Z")),
+      6,
+    );
+    expect(progressPointX(under, todayMs, todayX, dateToX)).toBeCloseTo(
+      dateToX(new Date("2024-01-01T00:00:00.000Z")),
+      6,
+    );
+  });
+});
+
+describe("buildProgressLinePoints", () => {
+  const rowOf = (t: ProgressLineTask, centerY: number): ProgressLineRow => ({
+    task: t,
+    centerY,
+  });
+
+  it("先頭/末尾は基準日ラインの端点、間は各タスクの進捗点を通る", () => {
+    const rows = [
+      rowOf(task("2024-01-01", "2024-01-11", 50), 10), // 遅れ → 左
+      rowOf(task("2024-01-01", "2024-01-11", 100), 30), // 前倒し → 右
+    ];
+    const points = buildProgressLinePoints(
+      rows,
+      todayMs,
+      todayX,
+      dateToX,
+      0,
+      100,
+    );
+    expect(points).toHaveLength(4);
+    expect(points[0]).toEqual({ x: todayX, y: 0 });
+    expect(points[3]).toEqual({ x: todayX, y: 100 });
+    expect(points[1].y).toBe(10);
+    expect(points[1].x).toBeLessThan(todayX);
+    expect(points[2].y).toBe(30);
+    expect(points[2].x).toBeGreaterThan(todayX);
+  });
+
+  it("マイルストーン/ゼロ期間の行はスキップする（端点のみ残る）", () => {
+    const rows = [
+      rowOf(task("2024-01-10", "2024-01-10", 0, true), 10),
+      rowOf(task("2024-01-10", "2024-01-10", 50), 30),
+    ];
+    const points = buildProgressLinePoints(
+      rows,
+      todayMs,
+      todayX,
+      dateToX,
+      0,
+      100,
+    );
+    // 進捗点は無くなり、端点2つのみ（today上の縦線）
+    expect(points).toEqual([
+      { x: todayX, y: 0 },
+      { x: todayX, y: 100 },
+    ]);
+  });
+
+  it("行が空でも端点2つを返す", () => {
+    const points = buildProgressLinePoints([], todayMs, todayX, dateToX, 5, 95);
+    expect(points).toEqual([
+      { x: todayX, y: 5 },
+      { x: todayX, y: 95 },
+    ]);
+  });
+});

--- a/src/__tests__/components/ganttv3/taskFormat.test.ts
+++ b/src/__tests__/components/ganttv3/taskFormat.test.ts
@@ -1,6 +1,7 @@
 import {
   formatMonthDay,
   formatYmd,
+  formatHours,
   statusColor,
 } from "@/components/ganttv3/utils/taskFormat";
 
@@ -23,6 +24,18 @@ describe("formatYmd", () => {
 
   it("undefined は空文字", () => {
     expect(formatYmd(undefined)).toBe("");
+  });
+});
+
+describe("formatHours", () => {
+  it("小数第1位に丸めて h を付与する", () => {
+    expect(formatHours(12.34)).toBe("12.3h");
+    expect(formatHours(8)).toBe("8h");
+    expect(formatHours(0)).toBe("0h");
+  });
+
+  it("undefined は undefined を返す", () => {
+    expect(formatHours(undefined)).toBeUndefined();
   });
 });
 

--- a/src/__tests__/components/ganttv3/useGanttDraftEditing.test.ts
+++ b/src/__tests__/components/ganttv3/useGanttDraftEditing.test.ts
@@ -4,10 +4,13 @@ import type { Task } from "@/components/ganttv3/gantt";
 import { makeTask, makeDependency } from "./_fixtures";
 
 jest.mock("@/app/wbs/[id]/actions/wbs-task-actions", () => ({
+  createTask: jest.fn(),
   updateTask: jest.fn(),
+  deleteTask: jest.fn(),
 }));
 jest.mock("@/app/wbs/[id]/actions/milestone-actions", () => ({
   updateMilestone: jest.fn(),
+  deleteMilestone: jest.fn(),
 }));
 jest.mock("@/app/wbs/[id]/ganttv3/dependency-actions", () => ({
   createGanttDependency: jest.fn(),
@@ -15,17 +18,29 @@ jest.mock("@/app/wbs/[id]/ganttv3/dependency-actions", () => ({
 }));
 jest.mock("@/hooks/use-toast", () => ({ toast: jest.fn() }));
 
-import { updateTask } from "@/app/wbs/[id]/actions/wbs-task-actions";
-import { updateMilestone } from "@/app/wbs/[id]/actions/milestone-actions";
+import {
+  createTask,
+  updateTask,
+  deleteTask,
+} from "@/app/wbs/[id]/actions/wbs-task-actions";
+import {
+  updateMilestone,
+  deleteMilestone,
+} from "@/app/wbs/[id]/actions/milestone-actions";
 import {
   createGanttDependency,
   deleteGanttDependency,
 } from "@/app/wbs/[id]/ganttv3/dependency-actions";
+import { toast } from "@/hooks/use-toast";
 
+const mockCreateTask = createTask as jest.Mock;
 const mockUpdateTask = updateTask as jest.Mock;
+const mockDeleteTask = deleteTask as jest.Mock;
 const mockUpdateMilestone = updateMilestone as jest.Mock;
+const mockDeleteMilestone = deleteMilestone as jest.Mock;
 const mockCreateDep = createGanttDependency as jest.Mock;
 const mockDeleteDep = deleteGanttDependency as jest.Mock;
+const mockToast = toast as jest.Mock;
 
 function setup(tasks: Task[]) {
   const refetchTasks = jest.fn().mockResolvedValue(undefined);
@@ -38,8 +53,11 @@ function setup(tasks: Task[]) {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockCreateTask.mockResolvedValue({ success: true });
   mockUpdateTask.mockResolvedValue({ success: true });
+  mockDeleteTask.mockResolvedValue({ success: true });
   mockUpdateMilestone.mockResolvedValue({ success: true });
+  mockDeleteMilestone.mockResolvedValue({ success: true });
   mockCreateDep.mockResolvedValue({ success: true });
   mockDeleteDep.mockResolvedValue({ success: true });
 });
@@ -172,5 +190,134 @@ describe("useGanttDraftEditing", () => {
     });
     expect(result.current.editMode).toBe(false);
     expect(mockUpdateTask).not.toHaveBeenCalled();
+  });
+
+  describe("handleDraftTaskAdd / handleDraftTaskDelete", () => {
+    it("ドラフトへタスクを追加すると chartTasks に反映される（dbId未設定）", () => {
+      const { result } = setup([makeTask({ id: "1", dbId: 10 })]);
+      act(() => result.current.handleEnterEditMode());
+      act(() =>
+        result.current.handleDraftTaskAdd(
+          makeTask({ id: "ignored", name: "新規タスク", phaseId: 5 }),
+        ),
+      );
+      expect(result.current.chartTasks).toHaveLength(2);
+      const added = result.current.chartTasks.find((t) => t.name === "新規タスク")!;
+      expect(added.dbId).toBeUndefined();
+      expect(added.id).not.toBe("ignored");
+    });
+
+    it("ドラフトからタスクを削除すると chartTasks から消え、他タスクの依存参照も除去される", () => {
+      const tasks = [
+        makeTask({ id: "1", dbId: 10 }),
+        makeTask({
+          id: "2",
+          dbId: 20,
+          predecessors: [makeDependency("1", { dbId: 5 })],
+        }),
+      ];
+      const { result } = setup(tasks);
+      act(() => result.current.handleEnterEditMode());
+      act(() => result.current.handleDraftTaskDelete(["1"]));
+      expect(result.current.chartTasks).toHaveLength(1);
+      expect(result.current.chartTasks[0].predecessors).toHaveLength(0);
+    });
+
+    it("保存: 新規追加タスクは createTask で作成される", async () => {
+      const { result, refetchTasks } = setup([makeTask({ id: "1", dbId: 10 })]);
+      act(() => result.current.handleEnterEditMode());
+      act(() =>
+        result.current.handleDraftTaskAdd(
+          makeTask({
+            id: "ignored",
+            name: "新規タスク",
+            phaseId: 5,
+            duration: 8,
+            assigneeId: 2,
+          }),
+        ),
+      );
+
+      await act(async () => {
+        await result.current.handleSaveEdit();
+      });
+
+      expect(mockCreateTask).toHaveBeenCalledTimes(1);
+      expect(mockCreateTask.mock.calls[0][0]).toBe(1); // wbsId
+      expect(mockCreateTask.mock.calls[0][1]).toMatchObject({
+        name: "新規タスク",
+        phaseId: 5,
+        assigneeId: "2",
+      });
+      // 既存タスクに変更が無ければ updateTask は呼ばれない
+      expect(mockUpdateTask).not.toHaveBeenCalled();
+      expect(refetchTasks).toHaveBeenCalledTimes(1);
+      expect(result.current.editMode).toBe(false);
+    });
+
+    it("保存: 削除されたタスクは種別ごとに削除APIが呼ばれる", async () => {
+      const tasks = [
+        makeTask({ id: "1", dbId: 10 }),
+        makeTask({ id: "2", dbId: 20, isMilestone: true }),
+      ];
+      const { result, refetchTasks } = setup(tasks);
+      act(() => result.current.handleEnterEditMode());
+      act(() => result.current.handleDraftTaskDelete(["1", "2"]));
+
+      await act(async () => {
+        await result.current.handleSaveEdit();
+      });
+
+      expect(mockDeleteTask).toHaveBeenCalledWith(10);
+      expect(mockDeleteMilestone).toHaveBeenCalledWith(20, 1);
+      expect(refetchTasks).toHaveBeenCalledTimes(1);
+    });
+
+    it("保存: 削除したタスクへの依存は明示的な削除APIを再度呼ばない（カスケード済み）", async () => {
+      const tasks = [
+        makeTask({ id: "1", dbId: 10 }),
+        makeTask({
+          id: "2",
+          dbId: 20,
+          predecessors: [makeDependency("1", { dbId: 5 })],
+        }),
+      ];
+      const { result } = setup(tasks);
+      act(() => result.current.handleEnterEditMode());
+      act(() => result.current.handleDraftTaskDelete(["1"]));
+
+      await act(async () => {
+        await result.current.handleSaveEdit();
+      });
+
+      expect(mockDeleteTask).toHaveBeenCalledWith(10);
+      // タスク削除のカスケードで依存も消えるため、依存削除APIは別途呼ばれない
+      expect(mockDeleteDep).not.toHaveBeenCalled();
+    });
+
+    it("保存: 新規タスクへの依存関係は作成されず警告トーストが出る", async () => {
+      const { result } = setup([makeTask({ id: "1", dbId: 10 })]);
+      act(() => result.current.handleEnterEditMode());
+      act(() =>
+        result.current.handleDraftTaskAdd(
+          makeTask({ id: "ignored", name: "新規タスク", phaseId: 5 }),
+        ),
+      );
+      const newTaskId = result.current.chartTasks.find(
+        (t) => t.name === "新規タスク",
+      )!.id;
+      act(() =>
+        result.current.handleDraftDependencyAdd(newTaskId, "1", "FS", 0),
+      );
+
+      await act(async () => {
+        await result.current.handleSaveEdit();
+      });
+
+      expect(mockCreateDep).not.toHaveBeenCalled();
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "一部の依存関係は保存されませんでした" }),
+      );
+    });
   });
 });

--- a/src/__tests__/components/ganttv3/useGanttMutations.test.ts
+++ b/src/__tests__/components/ganttv3/useGanttMutations.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from "@testing-library/react";
 import { useGanttMutations } from "@/components/ganttv3/hooks/useGanttMutations";
 import type { Task, GanttPhase } from "@/components/ganttv3/gantt";
-import { makeTask, makePhase, makeDependency } from "./_fixtures";
+import { makeTask, makeDependency } from "./_fixtures";
 
 jest.mock("@/app/wbs/[id]/actions/wbs-task-actions", () => ({
   createTask: jest.fn(),
@@ -105,28 +105,6 @@ describe("useGanttMutations", () => {
       });
       // 楽観的更新 + ロールバック
       expect(setTasks).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  describe("handleTaskAdd", () => {
-    it("成功時: createTask→refetchTasks", async () => {
-      const { result, refetchTasks } = setup([], [makePhase({ id: "5", name: "設計" })]);
-      await act(async () => {
-        await result.current.handleTaskAdd(makeTask({ id: "tmp", phaseId: undefined }));
-      });
-      expect(mockCreateTask).toHaveBeenCalledTimes(1);
-      // categories[0].id から phaseId を補完
-      expect(mockCreateTask.mock.calls[0][1]).toMatchObject({ phaseId: 5 });
-      expect(refetchTasks).toHaveBeenCalledTimes(1);
-    });
-
-    it("フェーズが無いと createTask せず終了", async () => {
-      const { result, refetchTasks } = setup([], []);
-      await act(async () => {
-        await result.current.handleTaskAdd(makeTask({ id: "tmp" }));
-      });
-      expect(mockCreateTask).not.toHaveBeenCalled();
-      expect(refetchTasks).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/wbs/[id]/ganttv3/actions.ts
+++ b/src/app/wbs/[id]/ganttv3/actions.ts
@@ -65,10 +65,12 @@ export async function getGanttTasks(wbsId: number): Promise<GanttTask[]> {
         for (const task of ganttTasks) {
             if (task.isMilestone || task.dbId === undefined) continue;
             const forecast = forecastByTaskId.get(String(task.dbId));
-            if (
-                forecast?.forecastEndDate &&
-                task.actualStartDate
-            ) {
+            if (!forecast) continue;
+
+            // 見通し工数はサイドバー表示用に、見通しバーの表示可否に関わらず常に付与する
+            task.forecastDuration = forecast.forecastHours;
+
+            if (forecast.forecastEndDate && task.actualStartDate) {
                 // 開始日は実績バーと揃えるため gantt タスク側の実績開始日を使う
                 task.forecastStartDate = task.actualStartDate;
                 task.forecastEndDate = forecast.forecastEndDate;
@@ -274,6 +276,7 @@ function convertTask(
             duration: task.yoteiKosu ?? 0,
             actualStartDate,
             actualEndDate,
+            actualDuration: task.jissekiKosu ?? undefined,
             color: color,
             isMilestone: false,
             progress,

--- a/src/components/ganttv3/gantt-chart.tsx
+++ b/src/components/ganttv3/gantt-chart.tsx
@@ -17,6 +17,7 @@ import {
   DependencyType,
 } from "./gantt";
 import { groupTasksByType } from "./utils/groupTasks";
+import { resolveBarColor } from "./utils/phase-colors";
 import {
   getScaleMultiplier,
   getTotalDays,
@@ -98,6 +99,8 @@ interface GanttChartProps {
   onCancelEdit?: () => void;
   /** 依存関係編集モーダルを開く */
   onEditDependencies?: (taskId: string) => void;
+  /** タスクを削除する（編集モードのインライン編集パネルから呼ばれる） */
+  onDeleteTask?: (taskId: string) => void;
   /** チャート上のドラッグ接続で依存関係を作成する（後続, 先行, タイプ, ラグ） */
   onDependencyCreate?: (
     successorTaskId: string,
@@ -143,6 +146,7 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
       onSaveEdit,
       onCancelEdit,
       onEditDependencies,
+      onDeleteTask,
       onDependencyCreate,
       isSaving = false,
       isDataLoading = false,
@@ -1045,6 +1049,14 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
             assignees={assignees}
             onChange={updateEditingField}
             onEditDependencies={onEditDependencies}
+            onDelete={
+              onDeleteTask
+                ? () => {
+                    onDeleteTask(editingTask.id);
+                    setEditingTaskId(null);
+                  }
+                : undefined
+            }
             onClose={() => setEditingTaskId(null)}
           />
         )}
@@ -1153,6 +1165,11 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                           task={row.task}
                           top={row.y}
                           height={row.height}
+                          barColor={resolveBarColor(
+                            row.task,
+                            style.colorMode,
+                            "planned",
+                          )}
                         />
                       );
                     }
@@ -1377,9 +1394,15 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                               actualEndX - actualX,
                               20,
                             );
+                            const actualColor = resolveBarColor(
+                              task,
+                              style.colorMode,
+                              "actual",
+                            );
                             actualBar = (
                               <g
                                 key={`${row.id}-actual`}
+                                data-testid="ganttv3-actual-bar"
                                 style={{ pointerEvents: "none" }}
                               >
                                 <rect
@@ -1388,9 +1411,9 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                                   width={actualWidth}
                                   height={TASK_HEIGHT}
                                   rx={4}
-                                  fill={task.color}
+                                  fill={actualColor}
                                   fillOpacity={0.55}
-                                  stroke={task.color}
+                                  stroke={actualColor}
                                   strokeWidth={1}
                                 />
                                 {style.labelPosition === "inside" && (
@@ -1423,6 +1446,11 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                               forecastEndX - forecastX,
                               20,
                             );
+                            const forecastColor = resolveBarColor(
+                              task,
+                              style.colorMode,
+                              "forecast",
+                            );
                             forecastBar = (
                               <g
                                 key={`${row.id}-forecast`}
@@ -1435,9 +1463,9 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                                   width={forecastWidth}
                                   height={TASK_HEIGHT}
                                   rx={4}
-                                  fill={task.color}
+                                  fill={forecastColor}
                                   fillOpacity={0.2}
-                                  stroke={task.color}
+                                  stroke={forecastColor}
                                   strokeWidth={1}
                                   strokeDasharray="4 2"
                                 />
@@ -1459,6 +1487,11 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                             <g key={row.id}>
                               <TaskBar
                                 task={task}
+                                barColor={resolveBarColor(
+                                  task,
+                                  style.colorMode,
+                                  "planned",
+                                )}
                                 x={dateToX(barStart)}
                                 y={plannedBarY}
                                 width={Math.max(

--- a/src/components/ganttv3/gantt-chart.tsx
+++ b/src/components/ganttv3/gantt-chart.tsx
@@ -40,6 +40,7 @@ import { TaskListRow } from "./task-list-row";
 import { InlineTaskEditPanel } from "./inline-task-edit-panel";
 import { GridLines } from "./grid-lines";
 import { DependencyArrows } from "./dependency-arrows";
+import { ProgressLine } from "./progress-line";
 import { Button } from "../ui/button";
 import {
   ChevronLeft,
@@ -1544,6 +1545,20 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                               ? handleArrowClick
                               : undefined
                           }
+                        />
+                      )}
+
+                      {/* イナズマ線（進捗線）。基準日ラインに対し各タスクの進捗を結ぶ */}
+                      {style.showProgressLine && (
+                        <ProgressLine
+                          tasks={visibleTasks}
+                          centerYById={taskCenterYById}
+                          dateToX={dateToX}
+                          timelineStart={timelineBounds.start}
+                          timelineEnd={timelineBounds.end}
+                          topY={0}
+                          bottomY={scrollContentHeight}
+                          color={style.colors.progressLine}
                         />
                       )}
 

--- a/src/components/ganttv3/gantt-v3-client.tsx
+++ b/src/components/ganttv3/gantt-v3-client.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useCallback, useEffect, useMemo } from "react";
 import type {
-  Task,
   TimelineScale,
   GanttStyle,
   GroupBy,
@@ -20,7 +19,7 @@ import {
   EMPTY_TASK_FILTER,
   filterTasks,
 } from "@/components/ganttv3/utils/taskFilter";
-import { TaskModal } from "@/components/wbs/task-modal";
+import { TaskModal, type TaskFormValues } from "@/components/wbs/task-modal";
 import { HoursUnit, HOURS_UNIT_LABELS } from "@/utils/hours-converter";
 import { getGanttTasksTsv } from "@/app/wbs/[id]/ganttv3/export-actions";
 import { groupTasksByType } from "@/components/ganttv3/utils/groupTasks";
@@ -173,16 +172,7 @@ export function GanttV3Client({ wbsId }: GanttV3ClientProps) {
 
   // タスク追加モーダルの「作成」→ サーバーへは送らずドラフトへ追加する（保存時にDB反映）
   const handleCreateDraftTask = useCallback(
-    (values: {
-      name: string;
-      assigneeId: string;
-      yoteiStartDate: string;
-      yoteiEndDate: string;
-      yoteiKosu: number;
-      status: Task["status"];
-      progressRate?: number;
-      phaseId: number;
-    }) => {
+    (values: TaskFormValues) => {
       const phase = categories.find((c) => c.id === String(values.phaseId));
       const assigneeId = Number(values.assigneeId);
       // フォームの日付は "YYYY/MM/DD"（タイムゾーン情報なし）のため、

--- a/src/components/ganttv3/gantt-v3-client.tsx
+++ b/src/components/ganttv3/gantt-v3-client.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect, useMemo } from "react";
 import type {
+  Task,
   TimelineScale,
   GanttStyle,
   GroupBy,
@@ -27,6 +28,7 @@ import { useGanttData } from "@/components/ganttv3/hooks/useGanttData";
 import { useGanttMutations } from "@/components/ganttv3/hooks/useGanttMutations";
 import { useGanttDraftEditing } from "@/components/ganttv3/hooks/useGanttDraftEditing";
 import { toWbsTask } from "@/components/ganttv3/utils/taskMapper";
+import { fromDateInputValue } from "@/components/ganttv3/utils/dateInput";
 import { createTaskColumns } from "@/components/ganttv3/taskTableColumns";
 import { tsvBlob, downloadBlob } from "@/components/ganttv3/utils/downloadBlob";
 import { toErrorMessage } from "@/components/ganttv3/utils/toErrorMessage";
@@ -38,6 +40,7 @@ const defaultGanttStyle: GanttStyle = {
   showProgress: true,
   showActual: false,
   showForecast: false,
+  colorMode: "phase",
   showDependencies: true,
   showCriticalPath: true,
   showWeekends: true,
@@ -81,6 +84,8 @@ export function GanttV3Client({ wbsId }: GanttV3ClientProps) {
   const [dependencyTaskId, setDependencyTaskId] = useState<string | null>(null);
   // バークリックで開くタスク詳細サイドバーの対象ID
   const [detailTaskId, setDetailTaskId] = useState<string | null>(null);
+  // タスク追加モーダル（編集モード中のみ開ける。追加内容はドラフトへ反映し、保存でDBへ反映）
+  const [isAddingTask, setIsAddingTask] = useState(false);
 
   // テーブルの工数表示単位（時間 / 人日）
   const [kosuUnit, setKosuUnit] = useState<HoursUnit>("hours"); // 工数表示単位
@@ -93,6 +98,8 @@ export function GanttV3Client({ wbsId }: GanttV3ClientProps) {
     handleEnterEditMode,
     handleCancelEdit,
     handleDraftTaskUpdate,
+    handleDraftTaskAdd,
+    handleDraftTaskDelete,
     handleDraftDependencyAdd,
     handleDraftDependencyRemove,
     handleDraftDependencyUpdate,
@@ -126,7 +133,6 @@ export function GanttV3Client({ wbsId }: GanttV3ClientProps) {
   // 確定タスク/依存関係のサーバー反映（楽観的更新＋ロールバック）
   const {
     handleTaskUpdate,
-    handleTaskAdd,
     handleTaskDelete,
     handleTaskDuplicate,
     handleDependencyAdd,
@@ -164,6 +170,50 @@ export function GanttV3Client({ wbsId }: GanttV3ClientProps) {
   const handleEditDependencies = useCallback((taskId: string) => {
     setDependencyTaskId(taskId);
   }, []);
+
+  // タスク追加モーダルの「作成」→ サーバーへは送らずドラフトへ追加する（保存時にDB反映）
+  const handleCreateDraftTask = useCallback(
+    (values: {
+      name: string;
+      assigneeId: string;
+      yoteiStartDate: string;
+      yoteiEndDate: string;
+      yoteiKosu: number;
+      status: Task["status"];
+      progressRate?: number;
+      phaseId: number;
+    }) => {
+      const phase = categories.find((c) => c.id === String(values.phaseId));
+      const assigneeId = Number(values.assigneeId);
+      // フォームの日付は "YYYY/MM/DD"（タイムゾーン情報なし）のため、
+      // ブラウザのローカルTZ解釈に依存しないよう UTC 0時の Date へ正規化する
+      const startDate = fromDateInputValue(
+        values.yoteiStartDate.replace(/\//g, "-"),
+      );
+      const endDate = fromDateInputValue(values.yoteiEndDate.replace(/\//g, "-"));
+      if (!startDate || !endDate) return;
+      handleDraftTaskAdd({
+        name: values.name,
+        startDate,
+        endDate,
+        duration: values.yoteiKosu,
+        color: phase?.color ?? "#3B82F6",
+        isMilestone: false,
+        progress: values.progressRate ?? 0,
+        progressRate: values.progressRate,
+        predecessors: [],
+        level: 0,
+        isManuallyScheduled: true,
+        category: phase?.name,
+        assignee: assignees.find((a) => a.id === assigneeId)?.name,
+        status: values.status,
+        assigneeId,
+        phaseId: values.phaseId,
+      });
+      setIsAddingTask(false);
+    },
+    [categories, assignees, handleDraftTaskAdd],
+  );
 
   // カテゴリの展開/折りたたみ
   const handleCategoryToggle = useCallback((categoryName: string) => {
@@ -258,25 +308,15 @@ export function GanttV3Client({ wbsId }: GanttV3ClientProps) {
               style={ganttStyle}
               onStyleChange={setGanttStyle}
               selectedTasks={selectedTasks}
-              onAddTask={() => {
-                const newTask = {
-                  name: "New Task",
-                  startDate: new Date(),
-                  endDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-                  duration: 5,
-                  color: "#3B82F6",
-                  isMilestone: false,
-                  progress: 0,
-                  predecessors: [],
-                  level: 0,
-                  isManuallyScheduled: false,
-                  category: "TEST",
-                  description: "",
-                  resources: [],
-                };
-                handleTaskAdd(newTask);
+              onAddTask={() => setIsAddingTask(true)}
+              onDeleteTasks={() => {
+                if (editMode) {
+                  handleDraftTaskDelete(Array.from(selectedTasks));
+                  setSelectedTasks(new Set());
+                } else {
+                  handleTaskDelete(Array.from(selectedTasks));
+                }
               }}
-              onDeleteTasks={() => handleTaskDelete(Array.from(selectedTasks))}
               onDuplicateTasks={() =>
                 handleTaskDuplicate(Array.from(selectedTasks))
               }
@@ -285,7 +325,9 @@ export function GanttV3Client({ wbsId }: GanttV3ClientProps) {
               sortBy={sortBy}
               onSortByChange={setSortBy}
               onExportTsv={handleExportTsv}
-              taskOpsDisabled={editMode}
+              addDisabled={!editMode || isSavingEdit || isLoading}
+              duplicateDisabled={editMode}
+              deleteDisabled={isSavingEdit}
             />
 
             {/* カテゴリの展開/折りたたみ */}
@@ -353,6 +395,7 @@ export function GanttV3Client({ wbsId }: GanttV3ClientProps) {
             onSaveEdit={handleSaveEdit}
             onCancelEdit={handleCancelEdit}
             onEditDependencies={handleEditDependencies}
+            onDeleteTask={editMode ? (id) => handleDraftTaskDelete([id]) : undefined}
             onDependencyCreate={
               editMode ? handleDraftDependencyAdd : handleDependencyAdd
             }
@@ -390,6 +433,16 @@ export function GanttV3Client({ wbsId }: GanttV3ClientProps) {
             // ドラフトが陳腐化する（保存時に古い値で上書きされる）ため抑止する。
             if (!editMode) refetchTasks();
           }}
+        />
+      )}
+
+      {/* タスク追加モーダル（編集モードのみ開ける。追加はドラフトへ反映し、保存でDBへ反映） */}
+      {isAddingTask && (
+        <TaskModal
+          wbsId={wbsId}
+          isOpen={true}
+          onClose={() => setIsAddingTask(false)}
+          onCreateDraft={handleCreateDraftTask}
         />
       )}
 

--- a/src/components/ganttv3/gantt-v3-client.tsx
+++ b/src/components/ganttv3/gantt-v3-client.tsx
@@ -44,6 +44,7 @@ const defaultGanttStyle: GanttStyle = {
   showCriticalPath: true,
   showWeekends: true,
   showTodayLine: true,
+  showProgressLine: false,
   taskHeight: 16,
   rowSpacing: 4,
   labelPosition: "inside",
@@ -55,6 +56,7 @@ const defaultGanttStyle: GanttStyle = {
     criticalPath: "#DC2626",
     weekend: "#F3F4F6",
     today: "#F59E0B",
+    progressLine: "#DB2777",
   },
 };
 

--- a/src/components/ganttv3/gantt.ts
+++ b/src/components/ganttv3/gantt.ts
@@ -73,6 +73,7 @@ export interface GanttStyle {
   showCriticalPath: boolean;
   showWeekends: boolean;
   showTodayLine: boolean;
+  showProgressLine: boolean; // イナズマ線（進捗線）の表示
   taskHeight: number;
   rowSpacing: number;
   labelPosition: 'inside' | 'outside';
@@ -84,6 +85,7 @@ export interface GanttStyle {
     criticalPath: string;
     weekend: string;
     today: string;
+    progressLine: string; // イナズマ線の色
   };
 }
 

--- a/src/components/ganttv3/gantt.ts
+++ b/src/components/ganttv3/gantt.ts
@@ -8,8 +8,10 @@ export interface Task {
   duration: number; // 予定工数(時間)。暦日数ではない（実日程は startDate/endDate）
   actualStartDate?: Date; // 実績開始日
   actualEndDate?: Date; // 実績終了日（未完了で実績開始のみの場合は本日が入る）
+  actualDuration?: number; // 実績工数（時間）
   forecastStartDate?: Date; // 見通し開始日（実績開始日と同じ。実績なし・完了タスクは未設定）
   forecastEndDate?: Date; // 見通し終了日（残見通し工数を基準稼働時間で消化し終える営業日）
+  forecastDuration?: number; // 見通し工数（時間）
   color: string; // 色
   isMilestone: boolean; // マイルストーンかどうか
   progress: number; // 進捗（進捗測定方式で算出した実効値。表示用）
@@ -57,12 +59,16 @@ export type DependencyType = 'FS' | 'SS' | 'FF' | 'SF';
 
 export type TimelineScale = 'day' | 'week' | 'month' | 'quarter' | 'year';
 
+/** タスクバーの色分け方式（フェーズ別 or 予定/実績/見通し別） */
+export type GanttColorMode = 'phase' | 'planActualForecast';
+
 export interface GanttStyle {
   theme: 'modern' | 'classic';
   showGrid: boolean;
   showProgress: boolean;
   showActual: boolean; // 実績バー（予定の下段）の表示
   showForecast: boolean; // 見通しバー（実績の下段）の表示
+  colorMode: GanttColorMode; // タスクバーの色分け方式
   showDependencies: boolean;
   showCriticalPath: boolean;
   showWeekends: boolean;

--- a/src/components/ganttv3/hooks/useGanttDraftEditing.ts
+++ b/src/components/ganttv3/hooks/useGanttDraftEditing.ts
@@ -1,7 +1,14 @@
 import { useState, useCallback, useRef } from "react";
 import type { Task, DependencyType } from "../gantt";
-import { updateTask } from "@/app/wbs/[id]/actions/wbs-task-actions";
-import { updateMilestone } from "@/app/wbs/[id]/actions/milestone-actions";
+import {
+  createTask,
+  updateTask,
+  deleteTask,
+} from "@/app/wbs/[id]/actions/wbs-task-actions";
+import {
+  updateMilestone,
+  deleteMilestone,
+} from "@/app/wbs/[id]/actions/milestone-actions";
 import {
   createGanttDependency,
   deleteGanttDependency,
@@ -37,6 +44,8 @@ export function useGanttDraftEditing({
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   // ドラフトで新規追加した依存関係に振る一時ID（負値）
   const tempDepIdRef = useRef(-1);
+  // ドラフトで新規追加したタスクに振る一時ID（dbId未設定＝未保存タスクの目印）
+  const tempTaskIdRef = useRef(1);
 
   // チャートで表示・編集するタスク（編集中はドラフト、それ以外は確定タスク）
   const chartTasks = editMode && draftTasks ? draftTasks : tasks;
@@ -65,6 +74,44 @@ export function useGanttDraftEditing({
       prev
         ? calculateCriticalPath(
             prev.map((t) => (t.id === updatedTask.id ? updatedTask : t)),
+          )
+        : prev,
+    );
+  }, []);
+
+  // ドラフトへタスクを新規追加する（タスクモーダルの「追加」から呼ばれる）。
+  // dbId は付与しない（未保存の目印）。DBへの反映は保存時（handleSaveEdit）にまとめて行う。
+  const handleDraftTaskAdd = useCallback((newTask: Omit<Task, "id">) => {
+    const tempId = `new-task-${tempTaskIdRef.current}`;
+    tempTaskIdRef.current += 1;
+    setDraftTasks((prev) =>
+      prev
+        ? calculateCriticalPath([
+            ...prev,
+            {
+              ...newTask,
+              id: tempId,
+              predecessors: newTask.predecessors.map((p) => ({ ...p })),
+            },
+          ])
+        : prev,
+    );
+  }, []);
+
+  // ドラフトからタスクを削除する（DBへの反映は保存時にまとめて行う）。
+  // 削除対象を指す依存（predecessors）が他タスクに残らないよう併せて取り除く。
+  const handleDraftTaskDelete = useCallback((taskIds: string[]) => {
+    setDraftTasks((prev) =>
+      prev
+        ? calculateCriticalPath(
+            prev
+              .filter((t) => !taskIds.includes(t.id))
+              .map((t) => ({
+                ...t,
+                predecessors: t.predecessors.filter(
+                  (p) => !taskIds.includes(p.taskId),
+                ),
+              })),
           )
         : prev,
     );
@@ -158,8 +205,49 @@ export function useGanttDraftEditing({
     setIsSavingEdit(true);
     try {
       const origById = new Map(tasks.map((t) => [t.id, t]));
+      const draftIds = new Set(draftTasks.map((t) => t.id));
 
-      // 1) 予定開始日・終了日・工数（マイルストーンは日付）の変更を保存
+      // 1) ドラフトで新規追加したタスクを作成する（dbId未設定＝未保存の目印）
+      const newDraftTasks = draftTasks.filter((dt) => dt.dbId === undefined);
+      for (const dt of newDraftTasks) {
+        if (dt.isMilestone || !dt.phaseId) {
+          throw new Error(`「${dt.name}」の追加に失敗しました（フェーズが未設定です）`);
+        }
+        const res = await createTask(wbsId, {
+          name: dt.name,
+          periods: [
+            {
+              startDate: dt.startDate.toISOString(),
+              endDate: dt.endDate.toISOString(),
+              type: "YOTEI",
+              kosus: [{ kosu: dt.duration ?? 0, type: "NORMAL" }],
+            },
+          ],
+          status: dt.status ?? "NOT_STARTED",
+          assigneeId:
+            dt.assigneeId !== undefined ? String(dt.assigneeId) : undefined,
+          phaseId: dt.phaseId,
+        });
+        if (!res.success) {
+          throw new Error(res.error ?? `「${dt.name}」の追加に失敗しました`);
+        }
+      }
+
+      // 2) ドラフトで削除したタスクをサーバーから削除する。
+      // 紐づく実績データ（work_records）はDBのFK制約（ON DELETE SET NULL）により保持される。
+      const deletedTasks = tasks.filter((t) => !draftIds.has(t.id));
+      for (const t of deletedTasks) {
+        const dbId = t.dbId ?? parseDbId(t.id);
+        const res = t.isMilestone
+          ? await deleteMilestone(dbId, wbsId)
+          : await deleteTask(dbId);
+        if (!res.success) {
+          throw new Error(res.error ?? `「${t.name}」の削除に失敗しました`);
+        }
+      }
+
+      // 3) 予定開始日・終了日・工数（マイルストーンは日付）の変更を保存
+      // （新規追加タスクは dbId 未設定のため orig が見つからず自動的に対象外になる）
       for (const dt of draftTasks) {
         const orig = origById.get(dt.id);
         if (!orig) continue;
@@ -202,15 +290,40 @@ export function useGanttDraftEditing({
         }
       }
 
-      // 2) 依存関係の差分を保存
-      const { deletes, creates } = diffDependencies(tasks, draftTasks);
+      // 4) 依存関係の差分を保存。
+      // 削除済みタスクに関わる依存はタスク削除のカスケードで既に消えているため、
+      // 元タスク側からも削除済みタスク・削除済みタスクへの参照を除いてから差分を取る
+      // （残すと「既に無い依存行」への削除APIを再度呼んでしまう）。
+      const survivingOriginalTasks = tasks
+        .filter((t) => draftIds.has(t.id))
+        .map((t) => ({
+          ...t,
+          predecessors: t.predecessors.filter((p) => draftIds.has(p.taskId)),
+        }));
+      const { deletes, creates } = diffDependencies(
+        survivingOriginalTasks,
+        draftTasks,
+      );
       for (const dbId of deletes) {
         const res = await deleteGanttDependency(wbsId, dbId);
         if (!res.success) {
           throw new Error(res.error ?? "依存関係の削除に失敗しました");
         }
       }
-      for (const input of creates) {
+      // 新規追加タスク（未保存＝数値dbIdを持たない）が絡む依存は今回保存できないため除外する
+      const validCreates = creates.filter(
+        (c) =>
+          Number.isFinite(c.successorTaskId) &&
+          Number.isFinite(c.predecessorTaskId),
+      );
+      if (validCreates.length !== creates.length) {
+        toast({
+          title: "一部の依存関係は保存されませんでした",
+          description:
+            "新規追加したタスクに対する依存関係は、保存後に改めて設定してください。",
+        });
+      }
+      for (const input of validCreates) {
         const res = await createGanttDependency(wbsId, input);
         if (!res.success) {
           throw new Error(res.error ?? "依存関係の作成に失敗しました");
@@ -242,6 +355,8 @@ export function useGanttDraftEditing({
     handleEnterEditMode,
     handleCancelEdit,
     handleDraftTaskUpdate,
+    handleDraftTaskAdd,
+    handleDraftTaskDelete,
     handleDraftDependencyAdd,
     handleDraftDependencyRemove,
     handleDraftDependencyUpdate,

--- a/src/components/ganttv3/hooks/useGanttMutations.ts
+++ b/src/components/ganttv3/hooks/useGanttMutations.ts
@@ -100,59 +100,6 @@ export function useGanttMutations({
     [tasks, setTasks, wbsId],
   );
 
-  // タスク追加（サーバーに作成 → 再取得）
-  const handleTaskAdd = useCallback(
-    async (newTask: Omit<Task, "id">) => {
-      const phaseId =
-        newTask.phaseId ??
-        (categories[0] ? Number(categories[0].id) : undefined);
-      if (!phaseId) {
-        toast({
-          title: "タスクを追加できません",
-          description: "フェーズが存在しません",
-          variant: "destructive",
-        });
-        return;
-      }
-
-      try {
-        const result = await createTask(wbsId, {
-          name: newTask.name,
-          periods: [
-            {
-              startDate: newTask.startDate.toISOString(),
-              endDate: newTask.endDate.toISOString(),
-              type: "YOTEI",
-              kosus: [{ kosu: newTask.duration ?? 0, type: "NORMAL" }],
-            },
-          ],
-          status: newTask.status ?? "NOT_STARTED",
-          assigneeId: newTask.assigneeId
-            ? String(newTask.assigneeId)
-            : undefined,
-          phaseId,
-        });
-
-        if (result.success) {
-          await refetchTasks();
-        } else {
-          toast({
-            title: "タスクの追加に失敗しました",
-            description: result.error,
-            variant: "destructive",
-          });
-        }
-      } catch (error) {
-        toast({
-          title: "タスクの追加に失敗しました",
-          description: toErrorMessage(error),
-          variant: "destructive",
-        });
-      }
-    },
-    [wbsId, categories, refetchTasks],
-  );
-
   // タスク/マイルストーン削除（楽観的削除 → サーバー削除 → 失敗時は再取得で同期）
   const handleTaskDelete = useCallback(
     async (taskIds: string[]) => {
@@ -403,7 +350,6 @@ export function useGanttMutations({
 
   return {
     handleTaskUpdate,
-    handleTaskAdd,
     handleTaskDelete,
     handleTaskDuplicate,
     handleDependencyAdd,

--- a/src/components/ganttv3/index.ts
+++ b/src/components/ganttv3/index.ts
@@ -5,6 +5,7 @@ export { BarLabel } from './bar-label';
 export { TimelineHeader } from './timeline-header';
 export { GridLines } from './grid-lines';
 export { DependencyArrows } from './dependency-arrows';
+export { ProgressLine } from './progress-line';
 export { ViewSwitcher } from './view-switcher';
 export { QuickActions } from './quick-actions';
 export { TaskFilterControl } from './task-filter-control';

--- a/src/components/ganttv3/inline-task-edit-panel.tsx
+++ b/src/components/ganttv3/inline-task-edit-panel.tsx
@@ -1,6 +1,6 @@
 import type { Task } from "./gantt";
 import { Button } from "../ui/button";
-import { Link2, X } from "lucide-react";
+import { Link2, Trash2, X } from "lucide-react";
 import { toDateInputValue, fromDateInputValue } from "./utils/dateInput";
 
 export type AssigneeOption = { id: number; name: string };
@@ -14,6 +14,8 @@ interface InlineTaskEditPanelProps {
   onChange: (patch: Partial<Task>) => void;
   /** 依存関係編集モーダルを開く（任意） */
   onEditDependencies?: (taskId: string) => void;
+  /** タスクを削除する（指定時のみ削除ボタンを表示） */
+  onDelete?: () => void;
   /** パネルを閉じる */
   onClose: () => void;
 }
@@ -27,6 +29,7 @@ export const InlineTaskEditPanel = ({
   assignees,
   onChange,
   onEditDependencies,
+  onDelete,
   onClose,
 }: InlineTaskEditPanelProps) => {
   return (
@@ -147,6 +150,18 @@ export const InlineTaskEditPanel = ({
         >
           <Link2 className="w-4 h-4" />
           依存関係
+        </Button>
+      )}
+
+      {onDelete && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-2 text-destructive hover:text-destructive"
+          onClick={onDelete}
+        >
+          <Trash2 className="w-4 h-4" />
+          削除
         </Button>
       )}
 

--- a/src/components/ganttv3/progress-line.tsx
+++ b/src/components/ganttv3/progress-line.tsx
@@ -67,7 +67,9 @@ export const ProgressLine = memo(function ProgressLine({
     );
   }, [today, tasks, centerYById, dateToX, timelineStart, timelineEnd, topY, bottomY]);
 
-  if (!points) return null;
+  // points が端点のみ（進捗点が1つも無い）の場合は、本日ラインと重複する
+  // 意味のない縦線になるため描画しない
+  if (!points || points.length <= 2) return null;
 
   const pointsAttr = points.map((p) => `${round(p.x)},${round(p.y)}`).join(" ");
   // 頂点ドット（先頭・末尾の基準日端点は除く）

--- a/src/components/ganttv3/progress-line.tsx
+++ b/src/components/ganttv3/progress-line.tsx
@@ -1,0 +1,91 @@
+import { memo, useMemo } from "react";
+import type { Task } from "./gantt";
+import {
+  buildProgressLinePoints,
+  type ProgressLineRow,
+} from "./utils/progressLine";
+
+interface ProgressLineProps {
+  /** 可視タスク（上から順） */
+  tasks: Task[];
+  /** タスクID → 行中心Y座標 */
+  centerYById: Map<string, number>;
+  /** 日付→X座標の変換（タイムライン基準） */
+  dateToX: (date: Date) => number;
+  /** タイムラインの表示範囲（基準日が範囲外なら描画しない） */
+  timelineStart: Date;
+  timelineEnd: Date;
+  /** 折れ線の上端・下端Y（基準日ライン上の端点） */
+  topY: number;
+  bottomY: number;
+  /** 線色 */
+  color: string;
+  /** 基準日（既定は現在時刻）。テスト用に注入可能 */
+  today?: Date;
+}
+
+/** SVG座標の小数精度を抑える（rendering-svg-precision） */
+const round = (n: number): number => Math.round(n * 10) / 10;
+
+/**
+ * イナズマ線（進捗線）を描画する表示専用コンポーネント。
+ * 基準日の縦線に対し、各タスクの進捗点を上から結んだジグザグ線を描く。
+ * props で完結し、頻繁に変わる値には依存しないため memo 化する。
+ */
+export const ProgressLine = memo(function ProgressLine({
+  tasks,
+  centerYById,
+  dateToX,
+  timelineStart,
+  timelineEnd,
+  topY,
+  bottomY,
+  color,
+  today,
+}: ProgressLineProps) {
+  const points = useMemo(() => {
+    const now = today ?? new Date();
+    // 基準日がタイムライン範囲外なら比較基準が画面外のため描画しない
+    if (now < timelineStart || now > timelineEnd) return null;
+
+    const todayMs = now.getTime();
+    const todayX = dateToX(now);
+
+    const rows: ProgressLineRow[] = [];
+    for (const task of tasks) {
+      const centerY = centerYById.get(task.id);
+      if (centerY === undefined) continue;
+      rows.push({ task, centerY });
+    }
+    return buildProgressLinePoints(
+      rows,
+      todayMs,
+      todayX,
+      dateToX,
+      topY,
+      bottomY,
+    );
+  }, [today, tasks, centerYById, dateToX, timelineStart, timelineEnd, topY, bottomY]);
+
+  if (!points) return null;
+
+  const pointsAttr = points.map((p) => `${round(p.x)},${round(p.y)}`).join(" ");
+  // 頂点ドット（先頭・末尾の基準日端点は除く）
+  const vertices = points.slice(1, -1);
+
+  return (
+    <g data-testid="ganttv3-progress-line" className="pointer-events-none">
+      <polyline
+        points={pointsAttr}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      {vertices.map((p, i) => (
+        <circle key={i} cx={round(p.x)} cy={round(p.y)} r={2.5} fill={color} />
+      ))}
+    </g>
+  );
+});

--- a/src/components/ganttv3/quick-actions.tsx
+++ b/src/components/ganttv3/quick-actions.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { TimelineScale, GanttStyle, GroupBy, TaskSortBy } from "./gantt";
+import {
+  TimelineScale,
+  GanttStyle,
+  GanttColorMode,
+  GroupBy,
+  TaskSortBy,
+} from "./gantt";
 import { Button } from "../ui/button";
 import {
   Select,
@@ -9,6 +15,12 @@ import {
   SelectValue,
 } from "../ui/select";
 import { Separator } from "../ui/separator";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../ui/tooltip";
 import {
   Plus,
   Trash2,
@@ -25,6 +37,8 @@ import {
   ArrowUpDown,
   BarChart3,
   TrendingUp,
+  Palette,
+  Blend,
 } from "lucide-react";
 
 interface QuickActionsProps {
@@ -43,8 +57,51 @@ interface QuickActionsProps {
   onSortByChange?: (sortBy: TaskSortBy) => void;
   /** タスク一覧をTSVで出力。未指定なら出力ボタンは表示しない */
   onExportTsv?: () => void;
-  /** タスクの追加・複製・削除を無効化する（編集モード中はドラフト整合性のため抑止） */
-  taskOpsDisabled?: boolean;
+  /** タスク追加を無効化する（編集モードでない、または保存中・データ読込中） */
+  addDisabled?: boolean;
+  /** タスク複製を無効化する（編集モード中はドラフト整合性のため抑止） */
+  duplicateDisabled?: boolean;
+  /** タスク削除を無効化する（保存処理中） */
+  deleteDisabled?: boolean;
+}
+
+/** アイコンのみのシンプルなアクションボタン。ツールチップでボタン名を表示する。 */
+function IconActionButton({
+  label,
+  onClick,
+  disabled = false,
+  active = false,
+  variant = "outline",
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  active?: boolean;
+  variant?: "outline" | "destructive";
+  children: React.ReactNode;
+}) {
+  // disabled な <button> は hover/focus イベントが発火せず Radix Tooltip が開けないため、
+  // 常にラップ用の <span> を Tooltip のトリガーにする（span は disabled でもイベントを受け取れる）
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex" tabIndex={disabled ? 0 : -1}>
+          <Button
+            variant={active ? "default" : variant}
+            size="sm"
+            onClick={onClick}
+            disabled={disabled}
+            className="h-8 w-8 p-0"
+            aria-label={label}
+          >
+            {children}
+          </Button>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
 }
 
 /**
@@ -61,6 +118,7 @@ interface QuickActionsProps {
  *  クイックアクションバーは、ガントチャートの上部に配置されるバーです。
  *  タスクの追加、削除、複製、タイムラインスケールの変更、ガントチャートスタイルの変更を行うことができます。
  *  また、タスクの選択状態を表示することができます。
+ *  操作ボタンはアイコンのみで表示し、ツールチップでボタン名を表示する。
  */
 export const QuickActions = ({
   timelineScale,
@@ -76,7 +134,9 @@ export const QuickActions = ({
   sortBy = "taskNo",
   onSortByChange,
   onExportTsv,
-  taskOpsDisabled = false,
+  addDisabled = false,
+  duplicateDisabled = false,
+  deleteDisabled = false,
 }: QuickActionsProps) => {
   const getGroupIcon = (group: GroupBy) => {
     switch (group) {
@@ -91,251 +151,251 @@ export const QuickActions = ({
     }
   };
 
-  return (
-    <div className="flex items-center gap-3">
-      {/* タスク操作 */}
-      <div className="flex items-center gap-1">
-        <Button
-          size="sm"
-          onClick={onAddTask}
-          className="gap-2 disabled:bg-gray-400"
-          variant="outline"
-          disabled={taskOpsDisabled}
-        >
-          <Plus className="w-4 h-4" />
-          🚧タスク追加
-        </Button>
+  const setColorMode = (colorMode: GanttColorMode) =>
+    onStyleChange({ ...style, colorMode });
 
-        {selectedTasks.size > 0 && (
+  return (
+    <TooltipProvider>
+      <div className="flex items-center gap-3">
+        {/* タスク操作 */}
+        <div className="flex items-center gap-1">
+          <IconActionButton
+            label="タスク追加"
+            onClick={onAddTask}
+            disabled={addDisabled}
+          >
+            <Plus className="w-4 h-4" />
+          </IconActionButton>
+
+          {selectedTasks.size > 0 && (
+            <>
+              <IconActionButton
+                label={`複製（${selectedTasks.size}件）`}
+                onClick={onDuplicateTasks}
+                disabled={duplicateDisabled}
+              >
+                <Copy className="w-4 h-4" />
+              </IconActionButton>
+              <IconActionButton
+                label={`削除（${selectedTasks.size}件）`}
+                onClick={onDeleteTasks}
+                disabled={deleteDisabled}
+                variant="destructive"
+              >
+                <Trash2 className="w-4 h-4" />
+              </IconActionButton>
+            </>
+          )}
+        </div>
+
+        <Separator orientation="vertical" className="h-6" />
+
+        {/* グループ表示 */}
+        {onGroupByChange && (
           <>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onDuplicateTasks}
-              disabled={taskOpsDisabled}
-              className="gap-2"
-            >
-              <Copy className="w-4 h-4" />
-              複製 ({selectedTasks.size})
-            </Button>
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={onDeleteTasks}
-              disabled={taskOpsDisabled}
-              className="gap-2"
-            >
-              <Trash2 className="w-4 h-4" />
-              削除 ({selectedTasks.size})
-            </Button>
+            <div className="flex items-center gap-2">
+              <Select
+                value={groupBy}
+                onValueChange={(value: GroupBy) => {
+                  onGroupByChange(value);
+                }}
+              >
+                <SelectTrigger className="w-36">
+                  <div className="flex items-center gap-2">
+                    {getGroupIcon(groupBy)}
+                    <SelectValue />
+                  </div>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">
+                    <div className="flex items-center gap-2">
+                      <span>グループなし</span>
+                    </div>
+                  </SelectItem>
+                  <SelectItem value="phase">
+                    <div className="flex items-center gap-2">
+                      <span>フェーズ</span>
+                    </div>
+                  </SelectItem>
+                  <SelectItem value="assignee">
+                    <div className="flex items-center gap-2">
+                      <span>担当者</span>
+                    </div>
+                  </SelectItem>
+                  <SelectItem value="status">
+                    <div className="flex items-center gap-2">
+                      <span>ステータス</span>
+                    </div>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Separator orientation="vertical" className="h-6" />
+          </>
+        )}
+
+        {/* 並び順 */}
+        {onSortByChange && (
+          <>
+            <div className="flex items-center gap-2">
+              <Select
+                value={sortBy}
+                onValueChange={(value: TaskSortBy) => {
+                  onSortByChange(value);
+                }}
+              >
+                <SelectTrigger className="w-40">
+                  <div className="flex items-center gap-2">
+                    <ArrowUpDown className="w-4 h-4" />
+                    <SelectValue />
+                  </div>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="taskNo">タスクNo順</SelectItem>
+                  <SelectItem value="startDate">開始予定日順</SelectItem>
+                  <SelectItem value="assignee">担当者順</SelectItem>
+                  <SelectItem value="status">ステータス順</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Separator orientation="vertical" className="h-6" />
+          </>
+        )}
+
+        {/* タイムラインスケール */}
+        <div className="flex items-center gap-2 pl-2">
+          {/* <span className="text-sm font-medium">スケール:</span> */}
+          <Select
+            value={timelineScale}
+            onValueChange={(value: TimelineScale) => {
+              onTimelineScaleChange(value);
+            }}
+          >
+            <SelectTrigger className="w-28">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="day">日</SelectItem>
+              <SelectItem value="week">週</SelectItem>
+              <SelectItem value="month">月</SelectItem>
+              <SelectItem value="quarter">四半期</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Separator orientation="vertical" className="h-6" />
+
+        {/* 色分け方式 */}
+        <div className="flex items-center gap-1 pl-2">
+          <IconActionButton
+            label="フェーズで色分け"
+            onClick={() => setColorMode("phase")}
+            active={style.colorMode === "phase"}
+          >
+            <Palette className="w-4 h-4" />
+          </IconActionButton>
+          <IconActionButton
+            label="予定・実績・見通しで色分け"
+            onClick={() => setColorMode("planActualForecast")}
+            active={style.colorMode === "planActualForecast"}
+          >
+            <Blend className="w-4 h-4" />
+          </IconActionButton>
+        </div>
+
+        <Separator orientation="vertical" className="h-6" />
+
+        {/* 表示オプション */}
+        <div className="flex items-center gap-1 pl-2">
+          <IconActionButton
+            label="グリッド表示"
+            active={style.showGrid}
+            onClick={() =>
+              onStyleChange({
+                ...style,
+                showGrid: !style.showGrid,
+              })
+            }
+          >
+            <Grid3X3 className="w-4 h-4" />
+          </IconActionButton>
+
+          <IconActionButton
+            label="依存関係表示"
+            active={style.showDependencies}
+            onClick={() =>
+              onStyleChange({
+                ...style,
+                showDependencies: !style.showDependencies,
+              })
+            }
+          >
+            <GitBranch className="w-4 h-4" />
+          </IconActionButton>
+
+          <IconActionButton
+            label="クリティカルパス表示"
+            active={style.showCriticalPath}
+            onClick={() =>
+              onStyleChange({
+                ...style,
+                showCriticalPath: !style.showCriticalPath,
+              })
+            }
+          >
+            <Target className="w-4 h-4" />
+          </IconActionButton>
+
+          <IconActionButton
+            label="本日ライン表示"
+            active={style.showTodayLine}
+            onClick={() =>
+              onStyleChange({
+                ...style,
+                showTodayLine: !style.showTodayLine,
+              })
+            }
+          >
+            <Calendar className="w-4 h-4" />
+          </IconActionButton>
+
+          <IconActionButton
+            label="実績バー表示（予定の下段に実績を表示）"
+            active={style.showActual}
+            onClick={() =>
+              onStyleChange({
+                ...style,
+                showActual: !style.showActual,
+              })
+            }
+          >
+            <BarChart3 className="w-4 h-4" />
+          </IconActionButton>
+
+          <IconActionButton
+            label="見通しバー表示（実績の下段に見通しを表示）"
+            active={style.showForecast}
+            onClick={() =>
+              onStyleChange({
+                ...style,
+                showForecast: !style.showForecast,
+              })
+            }
+          >
+            <TrendingUp className="w-4 h-4" />
+          </IconActionButton>
+        </div>
+
+        {/* 出力 */}
+        {onExportTsv && (
+          <>
+            <Separator orientation="vertical" className="h-6" />
+            <IconActionButton label="タスク一覧をTSVで出力" onClick={onExportTsv}>
+              <Download className="w-4 h-4" />
+            </IconActionButton>
           </>
         )}
       </div>
-
-      <Separator orientation="vertical" className="h-6" />
-
-      {/* グループ表示 */}
-      {onGroupByChange && (
-        <>
-          <div className="flex items-center gap-2">
-            <Select
-              value={groupBy}
-              onValueChange={(value: GroupBy) => {
-                onGroupByChange(value);
-              }}
-            >
-              <SelectTrigger className="w-36">
-                <div className="flex items-center gap-2">
-                  {getGroupIcon(groupBy)}
-                  <SelectValue />
-                </div>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">
-                  <div className="flex items-center gap-2">
-                    <span>グループなし</span>
-                  </div>
-                </SelectItem>
-                <SelectItem value="phase">
-                  <div className="flex items-center gap-2">
-                    <span>フェーズ</span>
-                  </div>
-                </SelectItem>
-                <SelectItem value="assignee">
-                  <div className="flex items-center gap-2">
-                    <span>担当者</span>
-                  </div>
-                </SelectItem>
-                <SelectItem value="status">
-                  <div className="flex items-center gap-2">
-                    <span>ステータス</span>
-                  </div>
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <Separator orientation="vertical" className="h-6" />
-        </>
-      )}
-
-      {/* 並び順 */}
-      {onSortByChange && (
-        <>
-          <div className="flex items-center gap-2">
-            <Select
-              value={sortBy}
-              onValueChange={(value: TaskSortBy) => {
-                onSortByChange(value);
-              }}
-            >
-              <SelectTrigger className="w-40">
-                <div className="flex items-center gap-2">
-                  <ArrowUpDown className="w-4 h-4" />
-                  <SelectValue />
-                </div>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="taskNo">タスクNo順</SelectItem>
-                <SelectItem value="startDate">開始予定日順</SelectItem>
-                <SelectItem value="assignee">担当者順</SelectItem>
-                <SelectItem value="status">ステータス順</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <Separator orientation="vertical" className="h-6" />
-        </>
-      )}
-
-      {/* タイムラインスケール */}
-      <div className="flex items-center gap-2 pl-2">
-        {/* <span className="text-sm font-medium">スケール:</span> */}
-        <Select
-          value={timelineScale}
-          onValueChange={(value: TimelineScale) => {
-            onTimelineScaleChange(value);
-          }}
-        >
-          <SelectTrigger className="w-28">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="day">日</SelectItem>
-            <SelectItem value="week">週</SelectItem>
-            <SelectItem value="month">月</SelectItem>
-            <SelectItem value="quarter">四半期</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-
-      <Separator orientation="vertical" className="h-6" />
-
-      {/* 表示オプション */}
-      <div className="flex items-center gap-1 pl-2">
-        <Button
-          variant={style.showGrid ? "default" : "outline"}
-          size="sm"
-          title="グリッド表示"
-          onClick={() =>
-            onStyleChange({
-              ...style,
-              showGrid: !style.showGrid,
-            })
-          }
-        >
-          <Grid3X3 className="w-4 h-4" />
-        </Button>
-
-        <Button
-          variant={style.showDependencies ? "default" : "outline"}
-          size="sm"
-          title="依存関係表示"
-          onClick={() =>
-            onStyleChange({
-              ...style,
-              showDependencies: !style.showDependencies,
-            })
-          }
-        >
-          <GitBranch className="w-4 h-4" />
-        </Button>
-
-        <Button
-          variant={style.showCriticalPath ? "default" : "outline"}
-          size="sm"
-          title="クリティカルパス表示"
-          onClick={() =>
-            onStyleChange({
-              ...style,
-              showCriticalPath: !style.showCriticalPath,
-            })
-          }
-        >
-          <Target className="w-4 h-4" />
-        </Button>
-
-        <Button
-          variant={style.showTodayLine ? "default" : "outline"}
-          size="sm"
-          title="本日ライン表示"
-          onClick={() =>
-            onStyleChange({
-              ...style,
-              showTodayLine: !style.showTodayLine,
-            })
-          }
-        >
-          <Calendar className="w-4 h-4" />
-        </Button>
-
-        <Button
-          variant={style.showActual ? "default" : "outline"}
-          size="sm"
-          title="実績バー表示（予定の下段に実績を表示）"
-          className="gap-1"
-          onClick={() =>
-            onStyleChange({
-              ...style,
-              showActual: !style.showActual,
-            })
-          }
-        >
-          <BarChart3 className="w-4 h-4" />
-          実績
-        </Button>
-
-        <Button
-          variant={style.showForecast ? "default" : "outline"}
-          size="sm"
-          title="見通しバー表示（実績の下段に見通しを表示）"
-          className="gap-1"
-          onClick={() =>
-            onStyleChange({
-              ...style,
-              showForecast: !style.showForecast,
-            })
-          }
-        >
-          <TrendingUp className="w-4 h-4" />
-          見通し
-        </Button>
-      </div>
-
-      {/* 出力 */}
-      {onExportTsv && (
-        <>
-          <Separator orientation="vertical" className="h-6" />
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onExportTsv}
-            className="gap-2"
-            title="タスク一覧をTSVで出力"
-          >
-            <Download className="w-4 h-4" />
-            TSV出力
-          </Button>
-        </>
-      )}
-    </div>
+    </TooltipProvider>
   );
 };

--- a/src/components/ganttv3/quick-actions.tsx
+++ b/src/components/ganttv3/quick-actions.tsx
@@ -39,6 +39,7 @@ import {
   TrendingUp,
   Palette,
   Blend,
+  Zap,
 } from "lucide-react";
 
 interface QuickActionsProps {
@@ -357,6 +358,19 @@ export const QuickActions = ({
             }
           >
             <Calendar className="w-4 h-4" />
+          </IconActionButton>
+
+          <IconActionButton
+            label="イナズマ線（進捗線）表示"
+            active={style.showProgressLine}
+            onClick={() =>
+              onStyleChange({
+                ...style,
+                showProgressLine: !style.showProgressLine,
+              })
+            }
+          >
+            <Zap className="w-4 h-4" />
           </IconActionButton>
 
           <IconActionButton

--- a/src/components/ganttv3/task-bar.tsx
+++ b/src/components/ganttv3/task-bar.tsx
@@ -5,6 +5,8 @@ import { BarLabel } from "./bar-label";
 
 interface TaskBarProps {
   task: Task;
+  /** バーの表示色（色分けモードに応じて呼び出し側で解決した値）。未指定なら task.color を使う */
+  barColor?: string;
   x: number;
   y: number;
   width: number;
@@ -36,6 +38,7 @@ interface TaskBarProps {
 
 export const TaskBar = memo(function TaskBar({
   task,
+  barColor,
   x,
   y,
   width,
@@ -65,8 +68,8 @@ export const TaskBar = memo(function TaskBar({
   };
 
   const isOnCriticalPath = task.isOnCriticalPath && style.showCriticalPath;
-  // クリティカルパス上でもバー色・枠線はフェーズ色（task.color）に合わせる
-  const taskColor = task.color;
+  // クリティカルパス上でもバー色・枠線は色分けモードで解決した色に合わせる
+  const taskColor = barColor ?? task.color;
 
   if (task.isMilestone) {
     // Render milestone as diamond

--- a/src/components/ganttv3/task-detail-sidebar.tsx
+++ b/src/components/ganttv3/task-detail-sidebar.tsx
@@ -1,7 +1,7 @@
 import { memo, type ReactNode } from "react";
 import type { Task } from "./gantt";
 import { getTaskStatusName } from "@/utils/utils";
-import { formatYmd } from "./utils/taskFormat";
+import { formatYmd, formatHours } from "./utils/taskFormat";
 import {
   Sheet,
   SheetContent,
@@ -96,6 +96,12 @@ export const TaskDetailSidebar = memo(function TaskDetailSidebar({
                   value={formatYmd(task.actualEndDate)}
                 />
               )}
+              {task.actualStartDate && (
+                <DetailRow
+                  label="実績工数"
+                  value={formatHours(task.actualDuration)}
+                />
+              )}
               {task.forecastStartDate && (
                 <DetailRow
                   label="見通し開始"
@@ -106,6 +112,12 @@ export const TaskDetailSidebar = memo(function TaskDetailSidebar({
                 <DetailRow
                   label="見通し終了"
                   value={formatYmd(task.forecastEndDate)}
+                />
+              )}
+              {task.forecastDuration !== undefined && (
+                <DetailRow
+                  label="見通し工数"
+                  value={formatHours(task.forecastDuration)}
                 />
               )}
               {task.isOnCriticalPath && (

--- a/src/components/ganttv3/task-list-row.tsx
+++ b/src/components/ganttv3/task-list-row.tsx
@@ -7,6 +7,8 @@ interface TaskListRowProps {
   task: Task;
   top: number;
   height: number;
+  /** 先頭ドットの表示色（色分けモードに応じて呼び出し側で解決した値）。未指定なら task.color を使う */
+  barColor?: string;
 }
 
 /**
@@ -18,6 +20,7 @@ export const TaskListRow = memo(function TaskListRow({
   task,
   top,
   height,
+  barColor,
 }: TaskListRowProps) {
   return (
     <div
@@ -35,7 +38,7 @@ export const TaskListRow = memo(function TaskListRow({
         )}
         <div
           className="w-2 h-2 flex-shrink-0"
-          style={{ backgroundColor: task.color }}
+          style={{ backgroundColor: barColor ?? task.color }}
         />
         <div className="w-16 flex-shrink-0 text-xs text-muted-foreground truncate">
           {task.taskNo ?? ""}

--- a/src/components/ganttv3/utils/phase-colors.ts
+++ b/src/components/ganttv3/utils/phase-colors.ts
@@ -1,3 +1,31 @@
+import type { GanttColorMode, Task } from "../gantt";
+
+/** 「予定/実績/見通し」色分けモードで使う固定パレット */
+export const PLAN_ACTUAL_FORECAST_COLORS: Record<
+  "planned" | "actual" | "forecast",
+  string
+> = {
+  planned: "#3B82F6", // blue
+  actual: "#10B981", // green
+  forecast: "#F59E0B", // amber
+};
+
+/**
+ * タスクバーの表示色を色分けモードに応じて解決する。
+ * - phase: フェーズ色（task.color）をそのまま使う（マイルストーンも常にこちら）
+ * - planActualForecast: 予定/実績/見通しの種別ごとに固定色を使う
+ */
+export function resolveBarColor(
+  task: Pick<Task, "color" | "isMilestone">,
+  colorMode: GanttColorMode,
+  barType: "planned" | "actual" | "forecast" = "planned",
+): string {
+  if (task.isMilestone || colorMode === "phase") {
+    return task.color;
+  }
+  return PLAN_ACTUAL_FORECAST_COLORS[barType];
+}
+
 /** フェーズ・グループに割り当てる色パレット */
 export const PHASE_COLOR_PALETTE = [
   "#3b82f6",

--- a/src/components/ganttv3/utils/progressLine.ts
+++ b/src/components/ganttv3/utils/progressLine.ts
@@ -1,0 +1,91 @@
+/**
+ * イナズマ線（進捗線 / progress line）の幾何計算（React 非依存の純粋関数）。
+ *
+ * イナズマ線は基準日（today）の縦線に対し、各タスクの進捗を「日付軸上の位置」として
+ * 点で表し、上から下へ結んだ折れ線。遅れているタスクは左へ、進んでいるタスクは右へ
+ * 張り出し、稲妻状のジグザグになる。
+ */
+
+/** 進捗点の算出に必要なタスクの最小情報 */
+export interface ProgressLineTask {
+  startDate: Date;
+  endDate: Date;
+  /** 実効進捗率（0–100）。表示用の progress を使う */
+  progress: number;
+  isMilestone: boolean;
+}
+
+/** 折れ線の頂点 */
+export interface ProgressLinePoint {
+  x: number;
+  y: number;
+}
+
+/** タスク行（進捗点の対象タスクと、その行の中心Y座標） */
+export interface ProgressLineRow {
+  task: ProgressLineTask;
+  centerY: number;
+}
+
+/**
+ * イナズマ線における1タスクの進捗点X座標を求める。
+ *
+ * 「基準日(today)を [start,end] にクランプした位置」を基準点とし、実績進捗に対応する
+ * 日付位置との偏差（px）を today ライン(todayX)へ加算する。これにより:
+ * - 進行中タスクは、予定より遅れていれば左・進んでいれば右へ張り出す
+ * - 未着手の将来タスク(0%)・完了済みの過去タスク(100%)は基準線上(todayX)に乗る
+ *   （MS Project の進捗線と同じ挙動。span 外のタスクが誤って左右へ張り出すのを防ぐ）
+ *
+ * @param task 対象タスク
+ * @param todayMs 基準日の epoch ミリ秒
+ * @param todayX 基準日の X 座標（= dateToX(today)）
+ * @param dateToX 日付→X座標の変換（タイムライン基準・日付に線形）
+ * @returns 進捗点X。マイルストーン／ゼロ期間タスクは進捗点を定義できず null。
+ */
+export function progressPointX(
+  task: ProgressLineTask,
+  todayMs: number,
+  todayX: number,
+  dateToX: (date: Date) => number,
+): number | null {
+  if (task.isMilestone) return null;
+
+  const startMs = task.startDate.getTime();
+  const endMs = task.endDate.getTime();
+  // ゼロ／負の期間は進捗を日付位置に写像できないため対象外
+  if (endMs <= startMs) return null;
+
+  const ratio = Math.max(0, Math.min(100, task.progress)) / 100;
+  // 実績進捗に対応する日付（バー上で進捗率に相当する位置）
+  const achievedMs = startMs + (endMs - startMs) * ratio;
+  // 基準日をタスク期間にクランプ（未着手／完了済みタスクを基準線上に乗せる）
+  const referenceMs = Math.min(Math.max(todayMs, startMs), endMs);
+
+  const deviation =
+    dateToX(new Date(achievedMs)) - dateToX(new Date(referenceMs));
+  return todayX + deviation;
+}
+
+/**
+ * イナズマ線の折れ線頂点列を組み立てる。
+ *
+ * 先頭は (todayX, topY)、各タスク行の進捗点を上から順に通り、末尾は (todayX, bottomY)。
+ * マイルストーン／ゼロ期間タスクは進捗点を持たないためスキップする（行はまたぐ）。
+ */
+export function buildProgressLinePoints(
+  rows: ProgressLineRow[],
+  todayMs: number,
+  todayX: number,
+  dateToX: (date: Date) => number,
+  topY: number,
+  bottomY: number,
+): ProgressLinePoint[] {
+  const points: ProgressLinePoint[] = [{ x: todayX, y: topY }];
+  for (const row of rows) {
+    const x = progressPointX(row.task, todayMs, todayX, dateToX);
+    if (x === null) continue;
+    points.push({ x, y: row.centerY });
+  }
+  points.push({ x: todayX, y: bottomY });
+  return points;
+}

--- a/src/components/ganttv3/utils/progressLine.ts
+++ b/src/components/ganttv3/utils/progressLine.ts
@@ -49,6 +49,8 @@ export function progressPointX(
   dateToX: (date: Date) => number,
 ): number | null {
   if (task.isMilestone) return null;
+  // 非有限な進捗率（NaN 等）は座標を定義できないため対象外（NaN頂点の混入を防ぐ）
+  if (!Number.isFinite(task.progress)) return null;
 
   const startMs = task.startDate.getTime();
   const endMs = task.endDate.getTime();

--- a/src/components/ganttv3/utils/taskFormat.ts
+++ b/src/components/ganttv3/utils/taskFormat.ts
@@ -17,6 +17,12 @@ export function formatYmd(date?: Date): string {
   return `${year}/${month}/${day}`;
 }
 
+/** 工数(時間)を小数第1位までに丸めて "12.5h" のように整形する（実績/見通し工数の表示用） */
+export function formatHours(hours?: number): string | undefined {
+  if (hours === undefined) return undefined;
+  return `${Math.round(hours * 10) / 10}h`;
+}
+
 /** ステータスを表す色（左リストのステータスドット用） */
 export function statusColor(status: Task["status"]): string {
   switch (status) {

--- a/src/components/task-scheduling/scheduling-gantt-preview.tsx
+++ b/src/components/task-scheduling/scheduling-gantt-preview.tsx
@@ -29,6 +29,7 @@ const previewStyle: GanttStyle = {
   showCriticalPath: false,
   showWeekends: true,
   showTodayLine: true,
+  showProgressLine: false,
   taskHeight: 16,
   rowSpacing: 4,
   labelPosition: "inside",
@@ -40,6 +41,7 @@ const previewStyle: GanttStyle = {
     criticalPath: "#DC2626",
     weekend: "#F3F4F6",
     today: "#F59E0B",
+    progressLine: "#DB2777",
   },
 };
 

--- a/src/components/task-scheduling/scheduling-gantt-preview.tsx
+++ b/src/components/task-scheduling/scheduling-gantt-preview.tsx
@@ -24,6 +24,7 @@ const previewStyle: GanttStyle = {
   showProgress: false,
   showActual: false,
   showForecast: false,
+  colorMode: "phase",
   showDependencies: true,
   showCriticalPath: false,
   showWeekends: true,

--- a/src/components/wbs/task-modal.tsx
+++ b/src/components/wbs/task-modal.tsx
@@ -109,6 +109,9 @@ const formSchema = z
     }
   );
 
+/** タスクモーダルのフォーム入力値（Zod スキーマから導出） */
+export type TaskFormValues = z.infer<typeof formSchema>;
+
 interface TaskModalProps {
   wbsId: number;
   task?: WbsTask;
@@ -120,7 +123,7 @@ interface TaskModalProps {
    * 入力内容をこのコールバックへ渡すだけにする（DBへの反映は呼び出し側に委ねる）。
    * ganttv3 の編集モードでタスクをドラフト追加する際に使用する。
    */
-  onCreateDraft?: (values: z.infer<typeof formSchema>) => void;
+  onCreateDraft?: (values: TaskFormValues) => void;
 }
 
 export function TaskModal({

--- a/src/components/wbs/task-modal.tsx
+++ b/src/components/wbs/task-modal.tsx
@@ -115,6 +115,12 @@ interface TaskModalProps {
   children?: ReactNode;
   isOpen?: boolean;
   onClose?: () => void;
+  /**
+   * 指定時、新規作成（task未指定）の送信で createTask を直接呼ばず、
+   * 入力内容をこのコールバックへ渡すだけにする（DBへの反映は呼び出し側に委ねる）。
+   * ganttv3 の編集モードでタスクをドラフト追加する際に使用する。
+   */
+  onCreateDraft?: (values: z.infer<typeof formSchema>) => void;
 }
 
 export function TaskModal({
@@ -123,6 +129,7 @@ export function TaskModal({
   children,
   isOpen: externalIsOpen,
   onClose,
+  onCreateDraft,
 }: TaskModalProps) {
   const [internalIsOpen, setInternalIsOpen] = useState(false);
   const isOpen = externalIsOpen !== undefined ? externalIsOpen : internalIsOpen;
@@ -228,6 +235,14 @@ export function TaskModal({
   async function onSubmit(values: z.infer<typeof formSchema>) {
     try {
       setIsSubmitting(true);
+      if (!task && onCreateDraft) {
+        onCreateDraft(values);
+        toast({
+          title: "タスクをガントに追加しました",
+          description: "「保存」を押すとDBに反映されます",
+        });
+        return;
+      }
       if (!task) {
         const result = await createTask(wbsId, {
           // id: values.id,


### PR DESCRIPTION
## Summary

This PR adds progress line (inazuma) visualization to the Gantt chart and refactors task operation controls in the quick actions bar. It also introduces granular disable flags for task operations and improves the color mode system for task bar rendering.

## Key Changes

### Progress Line (Inazuma) Visualization
- **New component**: `ProgressLine` renders a zigzag line showing task progress against a baseline date
  - Calculates progress points based on actual progress vs. planned schedule
  - Tasks ahead of schedule extend right; tasks behind extend left
  - Skips milestones and zero-duration tasks
- **New utility module**: `progressLine.ts` with pure functions for progress point calculation
  - `progressPointX()`: Computes X coordinate for a single task's progress point
  - `buildProgressLinePoints()`: Assembles the complete polyline path
  - Handles edge cases: future tasks (0%), completed tasks (100%), clamping to task span
- **Tests**: Comprehensive unit tests (`progressLine.test.ts`) and component tests (`ProgressLine.test.tsx`)
- **Style integration**: Added `showProgressLine` flag and `progressLine` color to `GanttStyle`

### Quick Actions Bar Refactoring
- **UI redesign**: Converted task operation buttons from text labels to icon-only buttons with tooltips
  - Uses new `IconActionButton` helper component wrapping buttons with `Tooltip`
  - Improves visual consistency and reduces clutter
  - Maintains accessibility via `aria-label` and tooltip content
- **Granular disable flags**: Replaced single `taskOpsDisabled` with three independent flags:
  - `addDisabled`: Controls task addition (editing mode, saving, or data loading)
  - `duplicateDisabled`: Controls task duplication (draft integrity during editing)
  - `deleteDisabled`: Controls task deletion (during save operations)
- **Tooltip provider**: Wrapped entire quick actions bar in `TooltipProvider` for consistent tooltip behavior

### Color Mode System
- **New type**: `GanttColorMode` ("phase" | "planActualForecast")
- **New utility**: `resolveBarColor()` function determines bar color based on mode
  - "phase" mode: Uses task's assigned color (existing behavior)
  - "planActualForecast" mode: Uses fixed colors for planned/actual/forecast bars
- **New palette**: `PLAN_ACTUAL_FORECAST_COLORS` with blue/green/amber scheme
- **UI controls**: Added icon buttons in quick actions to toggle color modes
- **Component updates**: `TaskBar` and `TaskListRow` accept optional `barColor` prop for color override

### Task Management in Draft Editing
- **New handlers**: `handleDraftTaskAdd()` and `handleDraftTaskDelete()` in `useGanttDraftEditing`
  - Add: Assigns temporary ID (dbId undefined) to new tasks; saved to DB on commit
  - Delete: Removes tasks and cleans up dependent references (predecessors)
- **Save logic**: Extended `handleSaveEdit()` to handle task creation and deletion
  - Creates new tasks via `createTask()` action
  - Deletes removed tasks via `deleteTask()` action
  - Maintains dependency integrity throughout
- **Modal integration**: `TaskModal` accepts optional `onDraftAdd` callback for draft-mode creation

### Test Coverage
- Added tests for progress line geometry and edge cases
- Updated `GanttChart` tests to verify progress line rendering and color mode behavior
- Extended `useGanttDraftEditing` tests for task add/delete operations
- Updated `QuickActions` tests to verify icon-only button layout and tooltip accessibility

## Notable Implementation Details

- **Progress line geometry**: Uses linear interpolation between task start/end dates and actual progress to determine achieved date; compares against baseline date (clamped to task span) to calculate deviation
- **Tooltip accessibility**: Disabled buttons don't fire hover events in Radix UI, so `IconActionButton` wraps the button in a `<span>` trigger to ensure tooltips work for disabled states
- **Draft task IDs**: New tasks use `new-task-{counter}` format during editing; dbId remains undefined until saved
-

https://claude.ai/code/session_012nT3qEHNMt3PyAXhZuJMa4