### PR TITLE
Remove unused ScheduleEntry type export from schedule actions

### DIFF
--- a/src/app/schedule/actions.ts
+++ b/src/app/schedule/actions.ts
@@ -9,8 +9,6 @@ import type { scheduleTsvData } from "@/types/csv";
 import type { ScheduleEntry } from "@/types/schedule";
 import type { ActionResult } from "@/types/action-result";
 
-export type { ScheduleEntry };
-
 function getScheduleApplicationService(): IScheduleApplicationService {
     return container.get<IScheduleApplicationService>(SYMBOL.IScheduleApplicationService);
 }


### PR DESCRIPTION
## Summary
Removed an unused type export from the schedule actions module to improve code cleanliness and reduce unnecessary exports.

## Changes
- Removed the `export type { ScheduleEntry };` statement from `src/app/schedule/actions.ts`
- The `ScheduleEntry` type is already imported from `@/types/schedule` and is used internally within the module, but the re-export was not being utilized by other parts of the codebase

## Details
This is a cleanup change that removes a redundant type export. The `ScheduleEntry` type remains available from its original source (`@/types/schedule`) for any code that needs it, so this change has no impact on the module's functionality or its consumers.

https://claude.ai/code/session_016VxwLtkcnLMTXQCJ5Nt7MR