### PR TITLE
Increase decimal precision in exported summary tables from 1 to 2

### DIFF
--- a/src/utils/export-table.ts
+++ b/src/utils/export-table.ts
@@ -112,14 +112,14 @@ export async function copyPhaseSummaryToClipboard(
     ...data.map(item => [
       item.phase,
       item.taskCount,
-      convertHours(item.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-      convertHours(item.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-      convertHours(item.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+      convertHours(item.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+      convertHours(item.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+      convertHours(item.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
     ]),
     ['合計', total.taskCount,
-      convertHours(total.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-      convertHours(total.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-      convertHours(total.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+      convertHours(total.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+      convertHours(total.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+      convertHours(total.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
     ]
   ];
 
@@ -184,14 +184,14 @@ export async function copyAssigneeSummaryToClipboard(
     ...data.map(item => [
       item.assignee,
       item.taskCount,
-      convertHours(item.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-      convertHours(item.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-      convertHours(item.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+      convertHours(item.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+      convertHours(item.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+      convertHours(item.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
     ]),
     ['合計', total.taskCount,
-      convertHours(total.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-      convertHours(total.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
-      convertHours(total.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+      convertHours(total.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+      convertHours(total.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+      convertHours(total.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
     ]
   ];
 
@@ -276,7 +276,7 @@ export async function copyMonthlyAssigneeSummaryToClipboard(
 ): Promise<void> {
   const unitSuffix = getUnitSuffix(unit);
   const fmt = (v: number) =>
-    convertHours(v, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+    convertHours(v, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
   const headers = [
     '担当者',
     ...data.months.flatMap(month => [
@@ -452,7 +452,7 @@ export async function copyMonthlyPhaseSummaryToClipboard(
 ): Promise<void> {
   const unitSuffix = getUnitSuffix(unit);
   const fmt = (v: number) =>
-    convertHours(v, unit).toLocaleString('ja-JP', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+    convertHours(v, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
   const headers = [
     '工程',
     ...data.months.flatMap(month => [


### PR DESCRIPTION
## Summary
Updated the number formatting for hour values in exported summary tables to display 2 decimal places instead of 1, providing greater precision in the exported data.

## Key Changes
- Modified `copyPhaseSummaryToClipboard()` to format planned hours, actual hours, and difference values with 2 decimal places
- Modified `copyAssigneeSummaryToClipboard()` to format planned hours, actual hours, and difference values with 2 decimal places
- Modified `copyMonthlyAssigneeSummaryToClipboard()` formatting function to use 2 decimal places
- Modified `copyMonthlyPhaseSummaryToClipboard()` formatting function to use 2 decimal places

## Implementation Details
Changed `toLocaleString()` options from `{ minimumFractionDigits: 1, maximumFractionDigits: 1 }` to `{ minimumFractionDigits: 2, maximumFractionDigits: 2 }` across all four export functions in `src/utils/export-table.ts`. This ensures consistent precision across all summary table exports (phase-based, assignee-based, and monthly variants).

https://claude.ai/code/session_01Ly9uKvfh1Yb32AB6Vov71s