### PR TITLE
実績・見通しバーのホバーでツールチップに対応する工数を表示

### DIFF
--- a/src/__tests__/components/gantt/BarLabel.test.tsx
+++ b/src/__tests__/components/gantt/BarLabel.test.tsx
@@ -20,6 +20,11 @@ describe("BarLabel", () => {
     expect(screen.getByText("実装 (8h)")).toBeInTheDocument();
   });
 
+  it("hours は小数第1位に丸めて表示する（実績/見通し工数など）", () => {
+    renderInSvg(<BarLabel {...baseProps} name="実装" hours={12.34} />);
+    expect(screen.getByText("実装 (12.3h)")).toBeInTheDocument();
+  });
+
   it("progress 指定かつ十分な幅なら進捗率を表示する", () => {
     renderInSvg(<BarLabel {...baseProps} name="実装" progress={40} />);
     expect(screen.getByText("40%")).toBeInTheDocument();

--- a/src/__tests__/components/gantt/GanttChart.test.tsx
+++ b/src/__tests__/components/gantt/GanttChart.test.tsx
@@ -782,8 +782,53 @@ describe("GanttChart", () => {
       );
       // タスクリスト行(1) + 予定/実績/見通しの3バー = 計4箇所
       expect(screen.getAllByText(/タスクA/).length).toBeGreaterThanOrEqual(4);
-      // 予定/実績/見通しの3バーとも「名前 + 工数」を表示（duration=2）
-      expect(screen.getAllByText("タスクA (2h)").length).toBe(3);
+    });
+
+    it("実績・見通しバーは予定工数ではなく、それぞれ実績工数・見通し工数をラベルに表示する", () => {
+      const withActual = [
+        makeTask({
+          id: "1",
+          name: "タスクA",
+          category: "設計",
+          duration: 2,
+          startDate: new Date("2024-01-01T00:00:00.000Z"),
+          endDate: new Date("2024-01-03T00:00:00.000Z"),
+          actualStartDate: new Date("2024-01-02T00:00:00.000Z"),
+          actualEndDate: new Date("2024-01-04T00:00:00.000Z"),
+          actualDuration: 3,
+          forecastStartDate: new Date("2024-01-02T00:00:00.000Z"),
+          forecastEndDate: new Date("2024-01-08T00:00:00.000Z"),
+          forecastDuration: 5,
+        }),
+      ];
+      const { container } = render(
+        <GanttChart
+          {...defaultProps}
+          tasks={withActual}
+          style={makeStyle({
+            showDependencies: false,
+            showTodayLine: false,
+            labelPosition: "inside",
+            showActual: true,
+            showForecast: true,
+          })}
+        />,
+      );
+
+      const plannedBar = container.querySelector('[data-task-id="1"]')!;
+      expect(within(plannedBar).getByText("タスクA (2h)")).toBeInTheDocument();
+
+      const actualBar = container.querySelector(
+        '[data-testid="gantt-actual-bar"]',
+      )!;
+      expect(within(actualBar).getByText("タスクA (3h)")).toBeInTheDocument();
+
+      const forecastBar = container.querySelector(
+        '[data-testid="gantt-forecast-bar"]',
+      )!;
+      expect(
+        within(forecastBar).getByText("タスクA (5h)"),
+      ).toBeInTheDocument();
     });
   });
 
@@ -845,6 +890,75 @@ describe("GanttChart", () => {
       expect(
         screen.queryByTestId("gantt-task-tooltip"),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("実績・見通しバーのホバーでツールチップ", () => {
+    const taskWithActualForecast = [
+      makeTask({
+        id: "1",
+        name: "タスクA",
+        category: "設計",
+        duration: 2,
+        startDate: new Date("2024-01-01T00:00:00.000Z"),
+        endDate: new Date("2024-01-03T00:00:00.000Z"),
+        actualStartDate: new Date("2024-01-02T00:00:00.000Z"),
+        actualEndDate: new Date("2024-01-05T00:00:00.000Z"),
+        actualDuration: 4,
+        forecastStartDate: new Date("2024-01-02T00:00:00.000Z"),
+        forecastEndDate: new Date("2024-01-09T00:00:00.000Z"),
+        forecastDuration: 6,
+      }),
+    ];
+    const styleWithBoth = makeStyle({
+      showDependencies: false,
+      showTodayLine: false,
+      showActual: true,
+      showForecast: true,
+    });
+
+    it("実績バーのホバーで実績期間・実績工数を表示し、離脱で消える", () => {
+      const { container } = render(
+        <GanttChart
+          {...defaultProps}
+          tasks={taskWithActualForecast}
+          style={styleWithBoth}
+        />,
+      );
+      const bar = container.querySelector('[data-testid="gantt-actual-bar"]')!;
+      fireEvent.mouseEnter(bar);
+      const tip = screen.getByTestId("gantt-task-tooltip");
+      expect(within(tip).getByText(/タスクA/)).toBeInTheDocument();
+      expect(within(tip).getByText("実績")).toBeInTheDocument();
+      expect(
+        within(tip).getByText("2024/01/02 〜 2024/01/05"),
+      ).toBeInTheDocument();
+      expect(within(tip).getByText("4h")).toBeInTheDocument();
+
+      fireEvent.mouseLeave(bar);
+      expect(
+        screen.queryByTestId("gantt-task-tooltip"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("見通しバーのホバーで見通し期間・見通し工数を表示する", () => {
+      const { container } = render(
+        <GanttChart
+          {...defaultProps}
+          tasks={taskWithActualForecast}
+          style={styleWithBoth}
+        />,
+      );
+      const bar = container.querySelector(
+        '[data-testid="gantt-forecast-bar"]',
+      )!;
+      fireEvent.mouseEnter(bar);
+      const tip = screen.getByTestId("gantt-task-tooltip");
+      expect(within(tip).getByText("見通し")).toBeInTheDocument();
+      expect(
+        within(tip).getByText("2024/01/02 〜 2024/01/09"),
+      ).toBeInTheDocument();
+      expect(within(tip).getByText("6h")).toBeInTheDocument();
     });
   });
 

--- a/src/__tests__/components/gantt/TaskTooltip.test.tsx
+++ b/src/__tests__/components/gantt/TaskTooltip.test.tsx
@@ -54,4 +54,63 @@ describe("TaskTooltip", () => {
     expect(tip).toHaveStyle({ left: "214px", top: "164px" });
     expect(tip).toHaveClass("fixed", "pointer-events-none");
   });
+
+  describe("variant による期間・工数の切り替え", () => {
+    const task = makeTask({
+      id: "1",
+      name: "タスク",
+      duration: 2,
+      startDate: new Date(2024, 0, 1),
+      endDate: new Date(2024, 0, 3),
+      actualStartDate: new Date(2024, 0, 2),
+      actualEndDate: new Date(2024, 0, 5),
+      actualDuration: 4,
+      forecastStartDate: new Date(2024, 0, 2),
+      forecastEndDate: new Date(2024, 0, 9),
+      forecastDuration: 6.25,
+    });
+
+    it("variant 未指定（既定）では予定期間・予定工数を表示する", () => {
+      render(<TaskTooltip task={task} x={0} y={0} />);
+      expect(screen.getByText("予定")).toBeInTheDocument();
+      expect(
+        screen.getByText("2024/01/01 〜 2024/01/03"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("2h")).toBeInTheDocument();
+    });
+
+    it("variant='actual' では実績期間・実績工数を表示する", () => {
+      render(<TaskTooltip task={task} x={0} y={0} variant="actual" />);
+      expect(screen.getByText("実績")).toBeInTheDocument();
+      expect(
+        screen.getByText("2024/01/02 〜 2024/01/05"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("4h")).toBeInTheDocument();
+      expect(screen.queryByText("予定")).not.toBeInTheDocument();
+    });
+
+    it("variant='forecast' では見通し期間・見通し工数（小数第1位に丸め）を表示する", () => {
+      render(<TaskTooltip task={task} x={0} y={0} variant="forecast" />);
+      expect(screen.getByText("見通し")).toBeInTheDocument();
+      expect(
+        screen.getByText("2024/01/02 〜 2024/01/09"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("6.3h")).toBeInTheDocument();
+    });
+
+    it("実績終了日が未設定なら実績開始日を終了側にも使う", () => {
+      const inProgress = makeTask({
+        id: "2",
+        name: "進行中タスク",
+        actualStartDate: new Date(2024, 0, 2),
+        actualDuration: 1,
+      });
+      render(
+        <TaskTooltip task={inProgress} x={0} y={0} variant="actual" />,
+      );
+      expect(
+        screen.getByText("2024/01/02 〜 2024/01/02"),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/gantt/bar-label.tsx
+++ b/src/components/gantt/bar-label.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import { formatHours } from "./utils/taskFormat";
 
 interface BarLabelProps {
   x: number;
@@ -37,7 +38,8 @@ export const BarLabel = memo(function BarLabel({
   if (width < MIN_LABEL_WIDTH) return null;
 
   const showProgress = progress != null && width >= MIN_PROGRESS_WIDTH;
-  const left = hours != null ? `${name} (${hours}h)` : name;
+  const hoursLabel = formatHours(hours);
+  const left = hoursLabel ? `${name} (${hoursLabel})` : name;
   // 行高に合わせて 9〜11px でフォントサイズを決める
   const fontSize = Math.min(11, Math.max(9, height - 5));
 

--- a/src/components/gantt/gantt-chart.tsx
+++ b/src/components/gantt/gantt-chart.tsx
@@ -15,6 +15,7 @@ import {
   GroupBy,
   TaskSortBy,
   DependencyType,
+  TaskBarVariant,
 } from "./gantt";
 import { groupTasksByType } from "./utils/groupTasks";
 import { resolveBarColor } from "./utils/phase-colors";
@@ -194,15 +195,23 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
     const [rowScale, setRowScale] = useState(1);
     const chartContentRef = useRef<HTMLDivElement>(null);
 
-    // ホバー中のタスクとカーソル位置（ツールチップ表示用）
+    // ホバー中のタスクとカーソル位置・バー種別（ツールチップ表示用）
     const [hoveredTask, setHoveredTask] = useState<{
       task: Task;
       x: number;
       y: number;
+      variant: TaskBarVariant;
     } | null>(null);
-    const handleBarHover = useCallback((task: Task, e: React.MouseEvent) => {
-      setHoveredTask({ task, x: e.clientX, y: e.clientY });
-    }, []);
+    const handleBarHover = useCallback(
+      (
+        task: Task,
+        e: React.MouseEvent,
+        variant: TaskBarVariant = "planned",
+      ) => {
+        setHoveredTask({ task, x: e.clientX, y: e.clientY, variant });
+      },
+      [],
+    );
     const handleBarHoverEnd = useCallback(() => setHoveredTask(null), []);
 
     // バークリック（非編集モード）→ 詳細サイドバー。ツールチップは閉じる。
@@ -1186,6 +1195,7 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                 task={hoveredTask.task}
                 x={hoveredTask.x}
                 y={hoveredTask.y}
+                variant={hoveredTask.variant}
               />
             )}
 
@@ -1404,7 +1414,10 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                               <g
                                 key={`${row.id}-actual`}
                                 data-testid="gantt-actual-bar"
-                                style={{ pointerEvents: "none" }}
+                                onMouseEnter={(e) =>
+                                  handleBarHover(task, e, "actual")
+                                }
+                                onMouseLeave={handleBarHoverEnd}
                               >
                                 <rect
                                   x={actualX}
@@ -1424,7 +1437,7 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                                     width={actualWidth}
                                     height={TASK_HEIGHT}
                                     name={task.name}
-                                    hours={task.duration}
+                                    hours={task.actualDuration}
                                   />
                                 )}
                               </g>
@@ -1456,7 +1469,10 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                               <g
                                 key={`${row.id}-forecast`}
                                 data-testid="gantt-forecast-bar"
-                                style={{ pointerEvents: "none" }}
+                                onMouseEnter={(e) =>
+                                  handleBarHover(task, e, "forecast")
+                                }
+                                onMouseLeave={handleBarHoverEnd}
                               >
                                 <rect
                                   x={forecastX}
@@ -1477,7 +1493,7 @@ export const GanttChart = forwardRef<HTMLDivElement, GanttChartProps>(
                                     width={forecastWidth}
                                     height={TASK_HEIGHT}
                                     name={task.name}
-                                    hours={task.duration}
+                                    hours={task.forecastDuration}
                                   />
                                 )}
                               </g>

--- a/src/components/gantt/gantt.ts
+++ b/src/components/gantt/gantt.ts
@@ -62,6 +62,9 @@ export type TimelineScale = 'day' | 'week' | 'month' | 'quarter' | 'year';
 /** タスクバーの色分け方式（フェーズ別 or 予定/実績/見通し別） */
 export type GanttColorMode = 'phase' | 'planActualForecast';
 
+/** タスクバーの種別（予定/実績/見通し）。ホバー時のツールチップ表示切替に使う */
+export type TaskBarVariant = 'planned' | 'actual' | 'forecast';
+
 export interface GanttStyle {
   theme: 'modern' | 'classic';
   showGrid: boolean;

--- a/src/components/gantt/task-tooltip.tsx
+++ b/src/components/gantt/task-tooltip.tsx
@@ -1,23 +1,33 @@
 import { memo } from "react";
-import type { Task } from "./gantt";
+import type { Task, TaskBarVariant } from "./gantt";
 import { getTaskStatusName } from "@/utils/utils";
-import { formatYmd } from "./utils/taskFormat";
+import { formatYmd, formatHours } from "./utils/taskFormat";
 
 interface TaskTooltipProps {
   task: Task;
   /** カーソルのビューポート座標（clientX/clientY） */
   x: number;
   y: number;
+  /** ホバー対象のバー種別（予定/実績/見通し）。既定は予定 */
+  variant?: TaskBarVariant;
 }
+
+const PERIOD_LABEL: Record<TaskBarVariant, string> = {
+  planned: "予定",
+  actual: "実績",
+  forecast: "見通し",
+};
 
 /**
  * タスクバーのホバー時に、重要な情報だけに絞って表示するツールチップ。
  * カーソル位置に `position: fixed` で追従表示する（クリックは透過）。
+ * バー種別（予定/実績/見通し）に応じて、期間・工数はそれぞれの値を表示する。
  */
 export const TaskTooltip = memo(function TaskTooltip({
   task,
   x,
   y,
+  variant = "planned",
 }: TaskTooltipProps) {
   const rows: { label: string; value: string }[] = [];
 
@@ -28,14 +38,37 @@ export const TaskTooltip = memo(function TaskTooltip({
       value: getTaskStatusName(task.status ?? "NOT_STARTED"),
     });
   }
+
+  const periodStart =
+    variant === "actual"
+      ? task.actualStartDate
+      : variant === "forecast"
+        ? task.forecastStartDate
+        : task.startDate;
+  const periodEnd =
+    (variant === "actual"
+      ? task.actualEndDate
+      : variant === "forecast"
+        ? task.forecastEndDate
+        : task.endDate) ?? periodStart;
+
   rows.push({
-    label: "予定",
-    value: task.isMilestone
-      ? formatYmd(task.startDate)
-      : `${formatYmd(task.startDate)} 〜 ${formatYmd(task.endDate)}`,
+    label: PERIOD_LABEL[variant],
+    value:
+      periodStart == null
+        ? "—"
+        : task.isMilestone
+          ? formatYmd(periodStart)
+          : `${formatYmd(periodStart)} 〜 ${formatYmd(periodEnd)}`,
   });
   if (!task.isMilestone) {
-    rows.push({ label: "工数", value: `${task.duration}h` });
+    const hours =
+      variant === "actual"
+        ? task.actualDuration
+        : variant === "forecast"
+          ? task.forecastDuration
+          : task.duration;
+    rows.push({ label: "工数", value: formatHours(hours) ?? "—" });
     rows.push({ label: "進捗", value: `${task.progress}%` });
   }
 


### PR DESCRIPTION
## 概要

ガントチャートの実績・見通しバーをホバーした際に、それぞれの工数（実績工数・見通し工数）をツールチップに表示するように対応しました。また、バーラベルにも対応する工数を表示し、小数第1位に丸めて表示するようにしました。

## 主な変更

### TaskTooltip コンポーネント
- `variant` プロップを追加し、バー種別（予定/実績/見通し）に応じて期間・工数を切り替える機能を実装
- `PERIOD_LABEL` マップで各バー種別のラベルを管理
- 実績終了日が未設定の場合は実績開始日を終了側にも使用する処理を追加
- `formatHours` ユーティリティを使用して工数を小数第1位に丸めて表示

### GanttChart コンポーネント
- `hoveredTask` の状態に `variant` フィールドを追加
- `handleBarHover` コールバックに `variant` パラメータを追加
- 実績バー・見通しバーのマウスイベントハンドラを実装し、ホバー時に対応する `variant` を渡すように修正
- 実績バー・見通しバーのラベル表示時に、対応する工数（`actualDuration`・`forecastDuration`）を使用するように修正

### BarLabel コンポーネント
- `formatHours` ユーティリティを使用して工数を小数第1位に丸めて表示

### taskFormat ユーティリティ
- `formatHours` 関数を追加し、工数を小数第1位に丸めるロジックを実装

## テスト

以下のテストを追加しました：

- **GanttChart.test.tsx**
  - 実績・見通しバーのラベルに対応する工数が表示されることを確認するテスト
  - 実績バーのホバーで実績期間・実績工数を表示し、離脱で消えることを確認するテスト
  - 見通しバーのホバーで見通し期間・見通し工数を表示することを確認するテスト

- **TaskTooltip.test.tsx**
  - `variant` 未指定時に予定期間・予定工数を表示することを確認するテスト
  - `variant='actual'` で実績期間・実績工数を表示することを確認するテスト
  - `variant='forecast'` で見通し期間・見通し工数（小数第1位に丸め）を表示することを確認するテスト
  - 実績終了日が未設定の場合の処理を確認するテスト

- **BarLabel.test.tsx**
  - 工数が小数第1位に丸めて表示されることを確認するテスト

## 実装の詳細

- `TaskBarVariant` 型を新規定義し、バー種別を型安全に管理
- ツールチップ表示時に、ホバー対象のバー種別に応じて期間・工数を動的に切り替える設計
- 小数工数（見通し工数など）の表示に対応し、小数第1位に丸めて表示

https://claude.ai/code/session_01K9CJJ2zKzoCVuaSktn7uz3