### PR TITLE
Add column visibility control for summary tables

### DIFF
--- a/src/__tests__/components/wbs/monthly-summary-table-columns.test.tsx
+++ b/src/__tests__/components/wbs/monthly-summary-table-columns.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import MonthlySummaryTable, {
+  SummaryCell,
+} from '@/components/wbs/monthly-summary-table';
+
+describe('MonthlySummaryTable - 列の表示切替', () => {
+  const cell: SummaryCell = {
+    plannedHours: 10,
+    actualHours: 8,
+    difference: -2,
+    baselineHours: 12,
+    forecastHours: 9,
+  };
+
+  const renderTable = (props: {
+    showBaseline: boolean;
+    showPlanned?: boolean;
+    showForecast: boolean;
+  }) =>
+    render(
+      <MonthlySummaryTable
+        months={['2024-01']}
+        rows={['田中']}
+        firstColumnHeader="担当者"
+        hoursUnit="hours"
+        showDifference={false}
+        getCell={() => cell}
+        rowTotals={{ 田中: cell }}
+        monthlyTotals={{ '2024-01': cell }}
+        grandTotal={cell}
+        {...props}
+      />
+    );
+
+  it('予定列を表示する場合は予定列が描画される', () => {
+    renderTable({ showBaseline: false, showPlanned: true, showForecast: false });
+
+    expect(screen.getAllByText('予定(h)').length).toBeGreaterThan(0);
+  });
+
+  it('予定列を非表示にした場合は予定列が描画されない', () => {
+    renderTable({
+      showBaseline: true,
+      showPlanned: false,
+      showForecast: true,
+    });
+
+    expect(screen.queryByText('予定(h)')).not.toBeInTheDocument();
+    expect(screen.getAllByText('基準(h)').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('見通(h)').length).toBeGreaterThan(0);
+  });
+
+  it('showPlanned未指定の場合は予定列が描画される', () => {
+    renderTable({ showBaseline: false, showForecast: false });
+
+    expect(screen.getAllByText('予定(h)').length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/utils/export-table.test.ts
+++ b/src/__tests__/utils/export-table.test.ts
@@ -1,0 +1,271 @@
+/**
+ * 集計表のコピー/出力ユーティリティのテスト
+ * - 工数は小数点第3位まで出力される
+ * - 表示設定で非表示にした列は出力されない
+ */
+import {
+  copyPhaseSummaryToClipboard,
+  copyAssigneeSummaryToClipboard,
+  copyMonthlyAssigneeSummaryToClipboard,
+  copyMonthlyPhaseSummaryToClipboard,
+  exportPhaseSummary,
+  exportMonthlyPhaseSummary,
+} from '@/utils/export-table';
+
+const originalBlob = global.Blob;
+
+let copiedText: string;
+let exportedText: string;
+
+beforeEach(() => {
+  copiedText = '';
+  exportedText = '';
+
+  document.execCommand = jest.fn().mockImplementation(() => {
+    const textarea = document.querySelector('textarea');
+    copiedText = textarea?.value ?? '';
+    return true;
+  });
+
+  // Blob の中身を検証するためのモック（jsdom では Blob の読み出しが扱いづらいため）
+  global.Blob = jest.fn().mockImplementation((parts: string[]) => {
+    exportedText = parts.join('');
+    return { parts };
+  }) as unknown as typeof Blob;
+
+  URL.createObjectURL = jest.fn().mockReturnValue('blob:mock');
+  URL.revokeObjectURL = jest.fn();
+  jest
+    .spyOn(HTMLAnchorElement.prototype, 'click')
+    .mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  global.Blob = originalBlob;
+  jest.restoreAllMocks();
+});
+
+const rowsOf = (tsv: string) => tsv.split('\n').map((line) => line.split('\t'));
+
+describe('工程別集計表', () => {
+  const data = [
+    { phase: '設計', taskCount: 2, plannedHours: 10, actualHours: 8.5, difference: -1.5 },
+  ];
+  const total = { taskCount: 2, plannedHours: 10, actualHours: 8.5, difference: -1.5 };
+
+  it('工数を小数点第3位まででコピーする', async () => {
+    await copyPhaseSummaryToClipboard(data, total, 'hours');
+
+    expect(rowsOf(copiedText)).toEqual([
+      ['工程', 'タスク数', '予定工数(h)', '実績工数(h)', '差分'],
+      ['設計', '2', '10.000', '8.500', '-1.500'],
+      ['合計', '2', '10.000', '8.500', '-1.500'],
+    ]);
+  });
+
+  it('単位変換後も小数点第3位まで出力する', async () => {
+    await copyPhaseSummaryToClipboard(data, total, 'days');
+
+    expect(rowsOf(copiedText)).toEqual([
+      ['工程', 'タスク数', '予定工数(人日)', '実績工数(人日)', '差分'],
+      ['設計', '2', '1.333', '1.133', '-0.200'],
+      ['合計', '2', '1.333', '1.133', '-0.200'],
+    ]);
+  });
+
+  it('非表示の列はコピーされない', async () => {
+    await copyPhaseSummaryToClipboard(data, total, 'hours', {
+      showPlanned: false,
+      showDifference: false,
+    });
+
+    expect(rowsOf(copiedText)).toEqual([
+      ['工程', 'タスク数', '実績工数(h)'],
+      ['設計', '2', '8.500'],
+      ['合計', '2', '8.500'],
+    ]);
+  });
+
+  it('非表示の列は出力されず、工数は小数点第3位まで出力される', () => {
+    exportPhaseSummary(data, total, 'tsv', 'hours', { showPlanned: false });
+
+    expect(rowsOf(exportedText.replace('﻿', ''))).toEqual([
+      ['工程', 'タスク数', '実績工数(h)', '差分'],
+      ['設計', '2', '8.500', '-1.500'],
+      ['合計', '2', '8.500', '-1.500'],
+    ]);
+  });
+});
+
+describe('担当者別集計表', () => {
+  const data = [
+    { assignee: '田中', taskCount: 1, plannedHours: 3.25, actualHours: 4, difference: 0.75 },
+  ];
+  const total = { taskCount: 1, plannedHours: 3.25, actualHours: 4, difference: 0.75 };
+
+  it('工数を小数点第3位まででコピーする', async () => {
+    await copyAssigneeSummaryToClipboard(data, total, 'hours');
+
+    expect(rowsOf(copiedText)).toEqual([
+      ['担当者', 'タスク数', '予定工数(h)', '実績工数(h)', '差分'],
+      ['田中', '1', '3.250', '4.000', '0.750'],
+      ['合計', '1', '3.250', '4.000', '0.750'],
+    ]);
+  });
+
+  it('非表示の列はコピーされない', async () => {
+    await copyAssigneeSummaryToClipboard(data, total, 'hours', {
+      showPlanned: false,
+    });
+
+    expect(rowsOf(copiedText)[0]).toEqual([
+      '担当者',
+      'タスク数',
+      '実績工数(h)',
+      '差分',
+    ]);
+  });
+});
+
+describe('月別・担当者別集計表', () => {
+  const monthlyData = {
+    months: ['2024-01'],
+    assignees: ['田中'],
+    data: [
+      {
+        month: '2024-01',
+        assignee: '田中',
+        plannedHours: 10,
+        actualHours: 8,
+        difference: -2,
+        baselineHours: 12,
+        forecastHours: 9,
+      },
+    ],
+    monthlyTotals: {
+      '2024-01': {
+        plannedHours: 10,
+        actualHours: 8,
+        difference: -2,
+        baselineHours: 12,
+        forecastHours: 9,
+      },
+    },
+    assigneeTotals: {
+      田中: {
+        plannedHours: 10,
+        actualHours: 8,
+        difference: -2,
+        baselineHours: 12,
+        forecastHours: 9,
+      },
+    },
+    grandTotal: {
+      plannedHours: 10,
+      actualHours: 8,
+      difference: -2,
+      baselineHours: 12,
+      forecastHours: 9,
+    },
+  };
+
+  it('表示中の列のみを小数点第3位までコピーする', async () => {
+    await copyMonthlyAssigneeSummaryToClipboard(monthlyData, 'hours', {
+      showBaseline: false,
+      showPlanned: true,
+      showActual: true,
+      showForecast: true,
+    });
+
+    expect(rowsOf(copiedText)).toEqual([
+      [
+        '担当者',
+        '2024-01_予定(h)',
+        '2024-01_実績(h)',
+        '2024-01_見通し(h)',
+        '合計_予定(h)',
+        '合計_実績(h)',
+        '合計_見通し(h)',
+      ],
+      ['田中', '10.000', '8.000', '9.000', '10.000', '8.000', '9.000'],
+      ['合計', '10.000', '8.000', '9.000', '10.000', '8.000', '9.000'],
+    ]);
+  });
+
+  it('予定列を非表示にした場合は予定列がコピーされない', async () => {
+    await copyMonthlyAssigneeSummaryToClipboard(monthlyData, 'hours', {
+      showBaseline: true,
+      showPlanned: false,
+      showActual: true,
+      showForecast: true,
+    });
+
+    expect(rowsOf(copiedText)[0]).toEqual([
+      '担当者',
+      '2024-01_基準(h)',
+      '2024-01_実績(h)',
+      '2024-01_見通し(h)',
+      '合計_基準(h)',
+      '合計_実績(h)',
+      '合計_見通し(h)',
+    ]);
+    expect(rowsOf(copiedText)[1]).toEqual([
+      '田中',
+      '12.000',
+      '8.000',
+      '9.000',
+      '12.000',
+      '8.000',
+      '9.000',
+    ]);
+  });
+});
+
+describe('月別・工程別集計表', () => {
+  const cell = {
+    taskCount: 1,
+    plannedHours: 10,
+    actualHours: 8,
+    difference: -2,
+    baselineHours: 12,
+    forecastHours: 9,
+  };
+  const monthlyPhaseData = {
+    months: ['2024-01'],
+    phases: ['設計'],
+    cells: new Map([['2024-01|設計', cell]]),
+    monthlyTotals: { '2024-01': cell },
+    phaseTotals: { 設計: cell },
+    grandTotal: cell,
+  };
+
+  it('表示中の列のみを小数点第3位までコピーする', async () => {
+    await copyMonthlyPhaseSummaryToClipboard(monthlyPhaseData, 'hours', {
+      showBaseline: true,
+      showPlanned: false,
+      showActual: true,
+      showForecast: false,
+    });
+
+    expect(rowsOf(copiedText)).toEqual([
+      ['工程', '2024-01_基準(h)', '2024-01_実績(h)', '合計_基準(h)', '合計_実績(h)'],
+      ['設計', '12.000', '8.000', '12.000', '8.000'],
+      ['合計', '12.000', '8.000', '12.000', '8.000'],
+    ]);
+  });
+
+  it('表示中の列のみを小数点第3位まで出力する', () => {
+    exportMonthlyPhaseSummary(monthlyPhaseData, 'tsv', 'hours', {
+      showBaseline: false,
+      showPlanned: true,
+      showActual: true,
+      showForecast: false,
+    });
+
+    expect(rowsOf(exportedText.replace('﻿', ''))).toEqual([
+      ['工程', '2024-01_予定(h)', '2024-01_実績(h)', '合計_予定(h)', '合計_実績(h)'],
+      ['設計', '10.000', '8.000', '10.000', '8.000'],
+      ['合計', '10.000', '8.000', '10.000', '8.000'],
+    ]);
+  });
+});

--- a/src/__tests__/utils/summary-column-visibility.test.ts
+++ b/src/__tests__/utils/summary-column-visibility.test.ts
@@ -1,0 +1,87 @@
+import {
+  SummaryColumnSettings,
+  canEnableSummaryColumn,
+  isSummaryColumnToggleDisabled,
+  toggleSummaryColumn,
+} from '@/utils/summary-column-visibility';
+
+describe('summary-column-visibility', () => {
+  const settings = (
+    overrides: Partial<SummaryColumnSettings> = {}
+  ): SummaryColumnSettings => ({
+    showBaseline: false,
+    showPlanned: true,
+    showForecast: false,
+    ...overrides,
+  });
+
+  describe('canEnableSummaryColumn', () => {
+    it('他の2列が非表示の場合は表示にできる', () => {
+      const current = settings({ showPlanned: false });
+      expect(canEnableSummaryColumn(current, 'planned')).toBe(true);
+      expect(canEnableSummaryColumn(current, 'baseline')).toBe(true);
+      expect(canEnableSummaryColumn(current, 'forecast')).toBe(true);
+    });
+
+    it('他の1列のみ表示中の場合は表示にできる', () => {
+      const current = settings({ showPlanned: true });
+      expect(canEnableSummaryColumn(current, 'baseline')).toBe(true);
+      expect(canEnableSummaryColumn(current, 'forecast')).toBe(true);
+    });
+
+    it('他の2列が表示中の場合は表示にできない（実績を含め4列すべて表示になるため）', () => {
+      expect(
+        canEnableSummaryColumn(
+          settings({ showPlanned: true, showForecast: true }),
+          'baseline'
+        )
+      ).toBe(false);
+      expect(
+        canEnableSummaryColumn(
+          settings({ showBaseline: true, showForecast: true }),
+          'planned'
+        )
+      ).toBe(false);
+      expect(
+        canEnableSummaryColumn(
+          settings({ showBaseline: true, showPlanned: true }),
+          'forecast'
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('toggleSummaryColumn', () => {
+    it('非表示への切り替えは常に反映される', () => {
+      const current = settings({ showBaseline: true, showPlanned: true });
+      expect(toggleSummaryColumn(current, 'planned', false)).toEqual(
+        settings({ showBaseline: true, showPlanned: false })
+      );
+    });
+
+    it('表示可能な場合は表示への切り替えが反映される', () => {
+      const current = settings({ showPlanned: true });
+      expect(toggleSummaryColumn(current, 'forecast', true)).toEqual(
+        settings({ showPlanned: true, showForecast: true })
+      );
+    });
+
+    it('4列すべて表示になる切り替えは無視される', () => {
+      const current = settings({ showBaseline: true, showPlanned: true });
+      expect(toggleSummaryColumn(current, 'forecast', true)).toEqual(current);
+    });
+  });
+
+  describe('isSummaryColumnToggleDisabled', () => {
+    it('表示中の列は常に切り替え可能', () => {
+      const current = settings({ showBaseline: true, showPlanned: true });
+      expect(isSummaryColumnToggleDisabled(current, 'baseline')).toBe(false);
+      expect(isSummaryColumnToggleDisabled(current, 'planned')).toBe(false);
+    });
+
+    it('表示にできない非表示の列は切り替え不可', () => {
+      const current = settings({ showBaseline: true, showPlanned: true });
+      expect(isSummaryColumnToggleDisabled(current, 'forecast')).toBe(true);
+    });
+  });
+});

--- a/src/components/wbs/monthly-assignee-summary.tsx
+++ b/src/components/wbs/monthly-assignee-summary.tsx
@@ -43,18 +43,22 @@ import MonthlySummaryTable, {
   SummaryCell,
 } from "@/components/wbs/monthly-summary-table";
 import { useState } from "react";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Settings } from "lucide-react";
+import SummaryDisplaySettings, {
+  SummaryDisplaySettingColumn,
+} from "@/components/wbs/summary-display-settings";
 
 interface MonthlyAssigneeSummaryProps {
   monthlyData: MonthlyAssigneeSummaryData;
   hoursUnit: HoursUnit;
   showDifference?: boolean;
   showBaseline?: boolean;
+  showPlanned?: boolean;
   showForecast?: boolean;
   onShowDifferenceChange?: (value: boolean) => void;
   onShowBaselineChange?: (value: boolean) => void;
+  onShowPlannedChange?: (value: boolean) => void;
   onShowForecastChange?: (value: boolean) => void;
+  isColumnToggleDisabled?: (column: SummaryDisplaySettingColumn) => boolean;
 }
 
 export function MonthlyAssigneeSummary({
@@ -62,16 +66,26 @@ export function MonthlyAssigneeSummary({
   hoursUnit,
   showDifference = true,
   showBaseline = false,
+  showPlanned = true,
   showForecast = false,
   onShowDifferenceChange,
   onShowBaselineChange,
+  onShowPlannedChange,
   onShowForecastChange,
+  isColumnToggleDisabled,
 }: MonthlyAssigneeSummaryProps) {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [selectedAssignee, setSelectedAssignee] = useState<string | null>(null);
   const [selectedMonth, setSelectedMonth] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<"monthly" | "task">("monthly");
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+
+  // コピー・出力は表示中の列のみを対象とする
+  const exportColumns = {
+    showBaseline,
+    showPlanned,
+    showActual: true,
+    showForecast,
+  };
 
   const formatNumber = (num: number) => {
     const converted = convertHours(num, hoursUnit);
@@ -151,66 +165,24 @@ export function MonthlyAssigneeSummary({
               </TooltipProvider>
             </CardTitle>
             <div className="flex gap-2">
-              <DropdownMenu
-                open={isSettingsOpen}
-                onOpenChange={setIsSettingsOpen}
-              >
-                <DropdownMenuTrigger asChild>
-                  <Button variant="outline" size="sm" className="gap-2">
-                    <Settings className="h-4 w-4" />
-                    表示設定
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-56">
-                  <div className="p-2 space-y-2">
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="show-difference"
-                        checked={showDifference}
-                        onCheckedChange={(checked) =>
-                          onShowDifferenceChange?.(!!checked)
-                        }
-                      />
-                      <label
-                        htmlFor="show-difference"
-                        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
-                      >
-                        月毎の差分を表示
-                      </label>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="show-baseline"
-                        checked={showBaseline}
-                        onCheckedChange={(checked) =>
-                          onShowBaselineChange?.(!!checked)
-                        }
-                      />
-                      <label
-                        htmlFor="show-baseline"
-                        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
-                      >
-                        月毎の基準を表示
-                      </label>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="show-forecast"
-                        checked={showForecast}
-                        onCheckedChange={(checked) =>
-                          onShowForecastChange?.(!!checked)
-                        }
-                      />
-                      <label
-                        htmlFor="show-forecast"
-                        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
-                      >
-                        月毎の見通しを表示
-                      </label>
-                    </div>
-                  </div>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <SummaryDisplaySettings
+                idPrefix="monthly-assignee"
+                columns={["difference", "baseline", "planned", "forecast"]}
+                values={{
+                  difference: showDifference,
+                  baseline: showBaseline,
+                  planned: showPlanned,
+                  forecast: showForecast,
+                }}
+                onChange={(column, next) => {
+                  if (column === "difference") onShowDifferenceChange?.(next);
+                  if (column === "baseline") onShowBaselineChange?.(next);
+                  if (column === "planned") onShowPlannedChange?.(next);
+                  if (column === "forecast") onShowForecastChange?.(next);
+                }}
+                isDisabled={isColumnToggleDisabled}
+                labelPrefix="月毎の"
+              />
               <Button
                 variant="outline"
                 size="sm"
@@ -222,7 +194,8 @@ export function MonthlyAssigneeSummary({
                         ...monthlyData,
                         assignees: monthlyData.assignees.map(a => a.key),
                       },
-                      hoursUnit
+                      hoursUnit,
+                      exportColumns
                     );
                     toast({
                       description: "TSV形式でクリップボードにコピーしました",
@@ -256,7 +229,8 @@ export function MonthlyAssigneeSummary({
                           assignees: monthlyData.assignees.map(a => a.key),
                         },
                         "csv",
-                        hoursUnit
+                        hoursUnit,
+                        exportColumns
                       )
                     }
                   >
@@ -270,7 +244,8 @@ export function MonthlyAssigneeSummary({
                           assignees: monthlyData.assignees.map(a => a.key),
                         },
                         "tsv",
-                        hoursUnit
+                        hoursUnit,
+                        exportColumns
                       )
                     }
                   >
@@ -290,6 +265,7 @@ export function MonthlyAssigneeSummary({
               hoursUnit={hoursUnit}
               showDifference={showDifference}
               showBaseline={showBaseline}
+              showPlanned={showPlanned}
               showForecast={showForecast}
               getCell={(assignee, month) => {
                 const data = monthlyData.data.find(

--- a/src/components/wbs/monthly-phase-summary.tsx
+++ b/src/components/wbs/monthly-phase-summary.tsx
@@ -20,20 +20,23 @@ import {
   copyMonthlyPhaseSummaryToClipboard,
   exportMonthlyPhaseSummary,
 } from "@/utils/export-table";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Settings } from "lucide-react";
-import { useState } from "react";
 import MonthlySummaryTable, { SummaryCell } from "@/components/wbs/monthly-summary-table";
+import SummaryDisplaySettings, {
+  SummaryDisplaySettingColumn,
+} from "@/components/wbs/summary-display-settings";
 
 interface MonthlyPhaseSummaryProps {
   monthlyData: MonthlyPhaseSummaryData;
   hoursUnit: HoursUnit;
   showDifference?: boolean;
   showBaseline?: boolean;
+  showPlanned?: boolean;
   showForecast?: boolean;
   onShowDifferenceChange?: (value: boolean) => void;
   onShowBaselineChange?: (value: boolean) => void;
+  onShowPlannedChange?: (value: boolean) => void;
   onShowForecastChange?: (value: boolean) => void;
+  isColumnToggleDisabled?: (column: SummaryDisplaySettingColumn) => boolean;
 }
 
 type Cell = {
@@ -50,12 +53,21 @@ export function MonthlyPhaseSummary({
   hoursUnit,
   showDifference = true,
   showBaseline = false,
+  showPlanned = true,
   showForecast = false,
   onShowDifferenceChange,
   onShowBaselineChange,
+  onShowPlannedChange,
   onShowForecastChange,
+  isColumnToggleDisabled,
 }: MonthlyPhaseSummaryProps) {
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  // コピー・出力は表示中の列のみを対象とする
+  const exportColumns = {
+    showBaseline,
+    showPlanned,
+    showActual: true,
+    showForecast,
+  };
   // const formatNumber = (num: number) => {
   //   const converted = convertHours(num, hoursUnit);
   //   return converted.toLocaleString("ja-JP", {
@@ -161,66 +173,24 @@ export function MonthlyPhaseSummary({
             月別・工程別集計表
           </CardTitle>
           <div className="flex gap-2">
-            <DropdownMenu
-              open={isSettingsOpen}
-              onOpenChange={setIsSettingsOpen}
-            >
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="sm" className="gap-2">
-                  <Settings className="h-4 w-4" />
-                  表示設定
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
-                <div className="p-2 space-y-2">
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="phase-show-difference"
-                      checked={showDifference}
-                      onCheckedChange={(checked) =>
-                        onShowDifferenceChange?.(!!checked)
-                      }
-                    />
-                    <label
-                      htmlFor="phase-show-difference"
-                      className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
-                    >
-                      月毎の差分を表示
-                    </label>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="phase-show-baseline"
-                      checked={showBaseline}
-                      onCheckedChange={(checked) =>
-                        onShowBaselineChange?.(!!checked)
-                      }
-                    />
-                    <label
-                      htmlFor="phase-show-baseline"
-                      className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
-                    >
-                      月毎の基準を表示
-                    </label>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="phase-show-forecast"
-                      checked={showForecast}
-                      onCheckedChange={(checked) =>
-                        onShowForecastChange?.(!!checked)
-                      }
-                    />
-                    <label
-                      htmlFor="phase-show-forecast"
-                      className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
-                    >
-                      月毎の見通しを表示
-                    </label>
-                  </div>
-                </div>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <SummaryDisplaySettings
+              idPrefix="monthly-phase"
+              columns={["difference", "baseline", "planned", "forecast"]}
+              values={{
+                difference: showDifference,
+                baseline: showBaseline,
+                planned: showPlanned,
+                forecast: showForecast,
+              }}
+              onChange={(column, next) => {
+                if (column === "difference") onShowDifferenceChange?.(next);
+                if (column === "baseline") onShowBaselineChange?.(next);
+                if (column === "planned") onShowPlannedChange?.(next);
+                if (column === "forecast") onShowForecastChange?.(next);
+              }}
+              isDisabled={isColumnToggleDisabled}
+              labelPrefix="月毎の"
+            />
             <Button
               variant="outline"
               size="sm"
@@ -236,7 +206,8 @@ export function MonthlyPhaseSummary({
                       phaseTotals,
                       grandTotal,
                     },
-                    hoursUnit
+                    hoursUnit,
+                    exportColumns
                   );
                   toast({
                     description: "TSV形式でクリップボードにコピーしました",
@@ -274,7 +245,8 @@ export function MonthlyPhaseSummary({
                         grandTotal,
                       },
                       "csv",
-                      hoursUnit
+                      hoursUnit,
+                      exportColumns
                     )
                   }
                 >
@@ -292,7 +264,8 @@ export function MonthlyPhaseSummary({
                         grandTotal,
                       },
                       "tsv",
-                      hoursUnit
+                      hoursUnit,
+                      exportColumns
                     )
                   }
                 >
@@ -313,6 +286,7 @@ export function MonthlyPhaseSummary({
             hoursUnit={hoursUnit}
             showDifference={showDifference}
             showBaseline={showBaseline}
+            showPlanned={showPlanned}
             showForecast={showForecast}
             getCell={(phase, month) => {
               const cell = cells.get(`${month}|${phase}`) || {

--- a/src/components/wbs/monthly-summary-table.tsx
+++ b/src/components/wbs/monthly-summary-table.tsx
@@ -29,6 +29,7 @@ interface MonthlySummaryTableProps {
     hoursUnit: HoursUnit; // 工数単位
     showDifference: boolean; // 差分表示
     showBaseline: boolean; // 基準工数表示
+    showPlanned?: boolean; // 予定工数表示（省略時は表示）
     showForecast: boolean; // 見通し工数表示
     // 指定 row, month のセルを取得。該当なしなら undefined
     getCell: (rowKey: string, month: string) => SummaryCell | undefined;
@@ -54,6 +55,7 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
     hoursUnit,
     showDifference,
     showBaseline,
+    showPlanned = true,
     showForecast,
     getCell,
     rowTotals,
@@ -88,7 +90,8 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
         return "text-blue-600"; // 実績が予定未達
     };
 
-    const monthColSpan = (showBaseline ? 1 : 0) + 2 /* 予定 + 実績 */ + (showForecast ? 1 : 0);
+    const monthColSpan =
+        (showBaseline ? 1 : 0) + (showPlanned ? 1 : 0) + 1 /* 実績 */ + (showForecast ? 1 : 0);
 
     // スタイル：先頭列固定幅
     const firstColStyle = (() => {
@@ -138,7 +141,9 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                             {showBaseline && (
                                 <TableHead className="text-center text-xs min-w-[60px]">基準({getUnitSuffix(hoursUnit)})</TableHead>
                             )}
-                            <TableHead className="text-center text-xs min-w-[60px]">予定({getUnitSuffix(hoursUnit)})</TableHead>
+                            {showPlanned && (
+                                <TableHead className="text-center text-xs min-w-[60px]">予定({getUnitSuffix(hoursUnit)})</TableHead>
+                            )}
                             <TableHead
                                 className={`text-center text-xs min-w-[60px] ${!showForecast ? "border-r" : ""}`}
                             >
@@ -155,7 +160,9 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                         {showBaseline && (
                             <TableHead className="text-center text-xs min-w-[60px]">基準({getUnitSuffix(hoursUnit)})</TableHead>
                         )}
-                        <TableHead className="text-center text-xs min-w-[60px]">予定({getUnitSuffix(hoursUnit)})</TableHead>
+                        {showPlanned && (
+                            <TableHead className="text-center text-xs min-w-[60px]">予定({getUnitSuffix(hoursUnit)})</TableHead>
+                        )}
                         <TableHead className="text-center text-xs min-w-[60px]">
                             {showDifference ? `実績(差分)(${getUnitSuffix(hoursUnit)})` : `実績(${getUnitSuffix(hoursUnit)})`}
                         </TableHead>
@@ -204,9 +211,11 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                                                 {baseline > 0 ? formatNumber(baseline) : "-"}
                                             </TableCell>
                                         )}
-                                        <TableCell className="text-center text-sm min-w-[60px]">
-                                            {planned > 0 ? formatNumber(planned) : "-"}
-                                        </TableCell>
+                                        {showPlanned && (
+                                            <TableCell className="text-center text-sm min-w-[60px]">
+                                                {planned > 0 ? formatNumber(planned) : "-"}
+                                            </TableCell>
+                                        )}
                                         <TableCell
                                             className={`text-center text-sm min-w-[60px] ${!showForecast ? "border-r" : ""}`}
                                         >
@@ -247,9 +256,11 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                                     {(total?.baselineHours || 0) > 0 ? formatNumber(total?.baselineHours || 0) : "-"}
                                 </TableCell>
                             )}
-                            <TableCell className="text-center text-sm font-semibold bg-gray-50">
-                                {formatNumber(total?.plannedHours || 0)}
-                            </TableCell>
+                            {showPlanned && (
+                                <TableCell className="text-center text-sm font-semibold bg-gray-50">
+                                    {formatNumber(total?.plannedHours || 0)}
+                                </TableCell>
+                            )}
                             <TableCell className="text-center text-sm font-semibold bg-gray-50">
                                 {formatNumber(total?.actualHours || 0)}
                                 {showDifference && (
@@ -295,9 +306,11 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                                         {baseline > 0 ? formatNumber(baseline) : "-"}
                                     </TableCell>
                                 )}
-                                <TableCell className="text-center text-sm">
-                                    {formatNumber(planned)}
-                                </TableCell>
+                                {showPlanned && (
+                                    <TableCell className="text-center text-sm">
+                                        {formatNumber(planned)}
+                                    </TableCell>
+                                )}
                                 <TableCell
                                     className={`text-center text-sm ${!showForecast ? "border-r" : ""}`}
                                 >
@@ -327,9 +340,11 @@ export const MonthlySummaryTable: React.FC<MonthlySummaryTableProps> = ({
                             {(grandTotal.baselineHours || 0) > 0 ? formatNumber(grandTotal.baselineHours || 0) : "-"}
                         </TableCell>
                     )}
-                    <TableCell className="text-center text-sm bg-gray-200">
-                        {formatNumber(grandTotal.plannedHours)}
-                    </TableCell>
+                    {showPlanned && (
+                        <TableCell className="text-center text-sm bg-gray-200">
+                            {formatNumber(grandTotal.plannedHours)}
+                        </TableCell>
+                    )}
                     <TableCell className="text-center text-sm bg-gray-200">
                         {formatNumber(grandTotal.actualHours)}
                         {showDifference && (

--- a/src/components/wbs/summary-display-settings.tsx
+++ b/src/components/wbs/summary-display-settings.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Settings } from "lucide-react";
+
+/** 表示設定で切り替えられる列 */
+export type SummaryDisplaySettingColumn =
+  | "difference"
+  | "baseline"
+  | "planned"
+  | "forecast";
+
+const COLUMN_LABELS: Record<SummaryDisplaySettingColumn, string> = {
+  difference: "差分を表示",
+  baseline: "基準を表示",
+  planned: "予定を表示",
+  forecast: "見通しを表示",
+};
+
+interface SummaryDisplaySettingsProps {
+  /** チェックボックスのid重複を避けるための接頭辞 */
+  idPrefix: string;
+  /** 表示する切替項目（表示順） */
+  columns: SummaryDisplaySettingColumn[];
+  /** 各列の現在の表示状態 */
+  values: Record<SummaryDisplaySettingColumn, boolean>;
+  /** 表示状態の変更 */
+  onChange: (column: SummaryDisplaySettingColumn, next: boolean) => void;
+  /** 切り替え不可の判定 */
+  isDisabled?: (column: SummaryDisplaySettingColumn) => boolean;
+  /** ラベルの接頭辞（例: 「月毎の」） */
+  labelPrefix?: string;
+}
+
+/**
+ * 集計表の表示設定ドロップダウン
+ */
+export function SummaryDisplaySettings({
+  idPrefix,
+  columns,
+  values,
+  onChange,
+  isDisabled,
+  labelPrefix = "",
+}: SummaryDisplaySettingsProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const hasDisabledColumn = columns.some((column) => isDisabled?.(column));
+
+  return (
+    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-2">
+          <Settings className="h-4 w-4" />
+          表示設定
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <div className="p-2 space-y-2">
+          {columns.map((column) => {
+            const id = `${idPrefix}-show-${column}`;
+            const disabled = isDisabled?.(column) ?? false;
+            return (
+              <div key={column} className="flex items-center space-x-2">
+                <Checkbox
+                  id={id}
+                  checked={values[column]}
+                  disabled={disabled}
+                  onCheckedChange={(checked) => onChange(column, !!checked)}
+                />
+                <label
+                  htmlFor={id}
+                  className={`text-sm font-medium leading-none ${
+                    disabled
+                      ? "cursor-not-allowed opacity-50"
+                      : "cursor-pointer"
+                  }`}
+                >
+                  {labelPrefix}
+                  {COLUMN_LABELS[column]}
+                </label>
+              </div>
+            );
+          })}
+          {hasDisabledColumn && (
+            <p className="text-xs text-gray-500 pt-1">
+              基準・予定・実績・見通しをすべて同時に表示することはできません
+            </p>
+          )}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export default SummaryDisplaySettings;

--- a/src/components/wbs/wbs-summary-tables.tsx
+++ b/src/components/wbs/wbs-summary-tables.tsx
@@ -43,6 +43,15 @@ import {
 } from "@/utils/hours-converter";
 import { Copy } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
+import SummaryDisplaySettings, {
+  SummaryDisplaySettingColumn,
+} from "@/components/wbs/summary-display-settings";
+import {
+  SummaryColumnSettings,
+  ToggleableSummaryColumn,
+  isSummaryColumnToggleDisabled,
+  toggleSummaryColumn,
+} from "@/utils/summary-column-visibility";
 
 interface WbsSummaryTablesProps {
   projectId: string;
@@ -53,10 +62,56 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
   const { data: summary, isLoading, error } = useWbsSummary(projectId, wbsId);
   const [hoursUnit, setHoursUnit] = useState<HoursUnit>("hours");
 
-  // 月別集計表の表示切り替え状態
-  const [showMonthlyDifference, setShowMonthlyDifference] = useState(true);
-  const [showMonthlyBaseline, setShowMonthlyBaseline] = useState(true);
-  const [showMonthlyForecast, setShowMonthlyForecast] = useState(true);
+  // 集計表の列の表示切り替え状態
+  // 基準・予定・実績・見通しの4列すべてが同時に表示されないよう、初期値は基準を非表示とする
+  const [showDifference, setShowDifference] = useState(true);
+  const [showBaseline, setShowBaseline] = useState(false);
+  const [showPlanned, setShowPlanned] = useState(true);
+  const [showForecast, setShowForecast] = useState(true);
+
+  const columnSettings: SummaryColumnSettings = {
+    showBaseline,
+    showPlanned,
+    showForecast,
+  };
+
+  // 基準・予定・見通しは同時に2列までしか表示できない
+  const changeColumnVisibility = (
+    column: ToggleableSummaryColumn,
+    next: boolean
+  ) => {
+    const updated = toggleSummaryColumn(columnSettings, column, next);
+    setShowBaseline(updated.showBaseline);
+    setShowPlanned(updated.showPlanned);
+    setShowForecast(updated.showForecast);
+  };
+
+  const isColumnToggleDisabled = (column: SummaryDisplaySettingColumn) =>
+    column === "difference"
+      ? false
+      : isSummaryColumnToggleDisabled(columnSettings, column);
+
+  // 工程別・担当者別集計表のコピー・出力対象の列（表示中の列のみ）
+  const categoryExportColumns = {
+    showPlanned,
+    showActual: true,
+    showDifference,
+  };
+
+  // 工程別・担当者別集計表の列数（工程/担当者・タスク数・実績 + 表示中の列）
+  const categoryColumnCount =
+    3 + (showPlanned ? 1 : 0) + (showDifference ? 1 : 0);
+
+  const handleCategoryColumnChange = (
+    column: SummaryDisplaySettingColumn,
+    next: boolean
+  ) => {
+    if (column === "difference") {
+      setShowDifference(next);
+      return;
+    }
+    changeColumnVisibility(column, next);
+  };
 
   const formatNumber = (num: number) => {
     const converted = convertHours(num, hoursUnit);
@@ -148,6 +203,18 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                 工程別集計表
               </CardTitle>
               <div className="flex gap-2">
+                <SummaryDisplaySettings
+                  idPrefix="phase-summary"
+                  columns={["planned", "difference"]}
+                  values={{
+                    difference: showDifference,
+                    baseline: showBaseline,
+                    planned: showPlanned,
+                    forecast: showForecast,
+                  }}
+                  onChange={handleCategoryColumnChange}
+                  isDisabled={isColumnToggleDisabled}
+                />
                 <Button
                   variant="outline"
                   size="sm"
@@ -157,7 +224,8 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                       await copyPhaseSummaryToClipboard(
                         summary.phaseSummaries,
                         summary.phaseTotal,
-                        hoursUnit
+                        hoursUnit,
+                        categoryExportColumns
                       );
                       toast({
                         description: "TSV形式でクリップボードにコピーしました",
@@ -189,7 +257,8 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                           summary.phaseSummaries,
                           summary.phaseTotal,
                           "csv",
-                          hoursUnit
+                          hoursUnit,
+                          categoryExportColumns
                         )
                       }
                     >
@@ -201,7 +270,8 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                           summary.phaseSummaries,
                           summary.phaseTotal,
                           "tsv",
-                          hoursUnit
+                          hoursUnit,
+                          categoryExportColumns
                         )
                       }
                     >
@@ -220,15 +290,19 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                   <TableHead className="text-center font-semibold">
                     タスク数
                   </TableHead>
-                  <TableHead className="text-right font-semibold">
-                    予定工数({getUnitSuffix(hoursUnit)})
-                  </TableHead>
+                  {showPlanned && (
+                    <TableHead className="text-right font-semibold">
+                      予定工数({getUnitSuffix(hoursUnit)})
+                    </TableHead>
+                  )}
                   <TableHead className="text-right font-semibold">
                     実績工数({getUnitSuffix(hoursUnit)})
                   </TableHead>
-                  <TableHead className="text-right font-semibold">
-                    差分
-                  </TableHead>
+                  {showDifference && (
+                    <TableHead className="text-right font-semibold">
+                      差分
+                    </TableHead>
+                  )}
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -238,19 +312,23 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                     <TableCell className="text-center">
                       {item.taskCount}
                     </TableCell>
-                    <TableCell className="text-right">
-                      {formatNumber(item.plannedHours)}
-                    </TableCell>
+                    {showPlanned && (
+                      <TableCell className="text-right">
+                        {formatNumber(item.plannedHours)}
+                      </TableCell>
+                    )}
                     <TableCell className="text-right">
                       {formatNumber(item.actualHours)}
                     </TableCell>
-                    <TableCell
-                      className={`text-right ${getDifferenceColor(
-                        item.difference
-                      )}`}
-                    >
-                      {formatNumber(item.difference)}
-                    </TableCell>
+                    {showDifference && (
+                      <TableCell
+                        className={`text-right ${getDifferenceColor(
+                          item.difference
+                        )}`}
+                      >
+                        {formatNumber(item.difference)}
+                      </TableCell>
+                    )}
                   </TableRow>
                 ))}
                 <TableRow className="bg-gray-50 font-semibold">
@@ -258,19 +336,23 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                   <TableCell className="text-center">
                     {summary.phaseTotal.taskCount}
                   </TableCell>
-                  <TableCell className="text-right">
-                    {formatNumber(summary.phaseTotal.plannedHours)}
-                  </TableCell>
+                  {showPlanned && (
+                    <TableCell className="text-right">
+                      {formatNumber(summary.phaseTotal.plannedHours)}
+                    </TableCell>
+                  )}
                   <TableCell className="text-right">
                     {formatNumber(summary.phaseTotal.actualHours)}
                   </TableCell>
-                  <TableCell
-                    className={`text-right ${getDifferenceColor(
-                      summary.phaseTotal.difference
-                    )}`}
-                  >
-                    {formatNumber(summary.phaseTotal.difference)}
-                  </TableCell>
+                  {showDifference && (
+                    <TableCell
+                      className={`text-right ${getDifferenceColor(
+                        summary.phaseTotal.difference
+                      )}`}
+                    >
+                      {formatNumber(summary.phaseTotal.difference)}
+                    </TableCell>
+                  )}
                 </TableRow>
               </TableBody>
             </Table>
@@ -287,6 +369,18 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
               </CardTitle>
               {summary.assigneeSummaries.length > 0 && (
                 <div className="flex gap-2">
+                  <SummaryDisplaySettings
+                    idPrefix="assignee-summary"
+                    columns={["planned", "difference"]}
+                    values={{
+                      difference: showDifference,
+                      baseline: showBaseline,
+                      planned: showPlanned,
+                      forecast: showForecast,
+                    }}
+                    onChange={handleCategoryColumnChange}
+                    isDisabled={isColumnToggleDisabled}
+                  />
                   <Button
                     variant="outline"
                     size="sm"
@@ -296,7 +390,8 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                         await copyAssigneeSummaryToClipboard(
                           summary.assigneeSummaries,
                           summary.assigneeTotal,
-                          hoursUnit
+                          hoursUnit,
+                          categoryExportColumns
                         );
                         toast({
                           description:
@@ -329,7 +424,8 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                             summary.assigneeSummaries,
                             summary.assigneeTotal,
                             "csv",
-                            hoursUnit
+                            hoursUnit,
+                            categoryExportColumns
                           )
                         }
                       >
@@ -341,7 +437,8 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                             summary.assigneeSummaries,
                             summary.assigneeTotal,
                             "tsv",
-                            hoursUnit
+                            hoursUnit,
+                            categoryExportColumns
                           )
                         }
                       >
@@ -361,15 +458,19 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                   <TableHead className="text-center font-semibold">
                     タスク数
                   </TableHead>
-                  <TableHead className="text-right font-semibold">
-                    予定工数({getUnitSuffix(hoursUnit)})
-                  </TableHead>
+                  {showPlanned && (
+                    <TableHead className="text-right font-semibold">
+                      予定工数({getUnitSuffix(hoursUnit)})
+                    </TableHead>
+                  )}
                   <TableHead className="text-right font-semibold">
                     実績工数({getUnitSuffix(hoursUnit)})
                   </TableHead>
-                  <TableHead className="text-right font-semibold">
-                    差分
-                  </TableHead>
+                  {showDifference && (
+                    <TableHead className="text-right font-semibold">
+                      差分
+                    </TableHead>
+                  )}
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -381,25 +482,29 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                     <TableCell className="text-center">
                       {item.taskCount}
                     </TableCell>
-                    <TableCell className="text-right">
-                      {formatNumber(item.plannedHours)}
-                    </TableCell>
+                    {showPlanned && (
+                      <TableCell className="text-right">
+                        {formatNumber(item.plannedHours)}
+                      </TableCell>
+                    )}
                     <TableCell className="text-right">
                       {formatNumber(item.actualHours)}
                     </TableCell>
-                    <TableCell
-                      className={`text-right ${getDifferenceColor(
-                        item.difference
-                      )}`}
-                    >
-                      {formatNumber(item.difference)}
-                    </TableCell>
+                    {showDifference && (
+                      <TableCell
+                        className={`text-right ${getDifferenceColor(
+                          item.difference
+                        )}`}
+                      >
+                        {formatNumber(item.difference)}
+                      </TableCell>
+                    )}
                   </TableRow>
                 ))}
                 {summary.assigneeSummaries.length === 0 && (
                   <TableRow>
                     <TableCell
-                      colSpan={5}
+                      colSpan={categoryColumnCount}
                       className="text-center text-gray-500 py-4"
                     >
                       担当者が割り当てられたタスクがありません
@@ -412,19 +517,23 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
                     <TableCell className="text-center">
                       {summary.assigneeTotal.taskCount}
                     </TableCell>
-                    <TableCell className="text-right">
-                      {formatNumber(summary.assigneeTotal.plannedHours)}
-                    </TableCell>
+                    {showPlanned && (
+                      <TableCell className="text-right">
+                        {formatNumber(summary.assigneeTotal.plannedHours)}
+                      </TableCell>
+                    )}
                     <TableCell className="text-right">
                       {formatNumber(summary.assigneeTotal.actualHours)}
                     </TableCell>
-                    <TableCell
-                      className={`text-right ${getDifferenceColor(
-                        summary.assigneeTotal.difference
-                      )}`}
-                    >
-                      {formatNumber(summary.assigneeTotal.difference)}
-                    </TableCell>
+                    {showDifference && (
+                      <TableCell
+                        className={`text-right ${getDifferenceColor(
+                          summary.assigneeTotal.difference
+                        )}`}
+                      >
+                        {formatNumber(summary.assigneeTotal.difference)}
+                      </TableCell>
+                    )}
                   </TableRow>
                 )}
               </TableBody>
@@ -437,12 +546,21 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
       <MonthlyAssigneeSummary
         monthlyData={summary.monthlyAssigneeSummary}
         hoursUnit={hoursUnit}
-        showDifference={showMonthlyDifference}
-        showBaseline={showMonthlyBaseline}
-        showForecast={showMonthlyForecast}
-        onShowDifferenceChange={setShowMonthlyDifference}
-        onShowBaselineChange={setShowMonthlyBaseline}
-        onShowForecastChange={setShowMonthlyForecast}
+        showDifference={showDifference}
+        showBaseline={showBaseline}
+        showPlanned={showPlanned}
+        showForecast={showForecast}
+        onShowDifferenceChange={setShowDifference}
+        onShowBaselineChange={(value) =>
+          changeColumnVisibility("baseline", value)
+        }
+        onShowPlannedChange={(value) =>
+          changeColumnVisibility("planned", value)
+        }
+        onShowForecastChange={(value) =>
+          changeColumnVisibility("forecast", value)
+        }
+        isColumnToggleDisabled={isColumnToggleDisabled}
       />
 
       {/* 月別・工程別集計表 */}
@@ -450,12 +568,21 @@ export function WbsSummaryTables({ projectId, wbsId }: WbsSummaryTablesProps) {
         <MonthlyPhaseSummary
           monthlyData={summary.monthlyPhaseSummary}
           hoursUnit={hoursUnit}
-          showDifference={showMonthlyDifference}
-          showBaseline={showMonthlyBaseline}
-          showForecast={showMonthlyForecast}
-          onShowDifferenceChange={setShowMonthlyDifference}
-          onShowBaselineChange={setShowMonthlyBaseline}
-          onShowForecastChange={setShowMonthlyForecast}
+          showDifference={showDifference}
+          showBaseline={showBaseline}
+          showPlanned={showPlanned}
+          showForecast={showForecast}
+          onShowDifferenceChange={setShowDifference}
+          onShowBaselineChange={(value) =>
+            changeColumnVisibility("baseline", value)
+          }
+          onShowPlannedChange={(value) =>
+            changeColumnVisibility("planned", value)
+          }
+          onShowForecastChange={(value) =>
+            changeColumnVisibility("forecast", value)
+          }
+          isColumnToggleDisabled={isColumnToggleDisabled}
         />
       )}
     </div>

--- a/src/utils/export-table.ts
+++ b/src/utils/export-table.ts
@@ -6,6 +6,54 @@ interface ExportOptions {
 }
 
 /**
+ * 集計表の列表示設定。
+ * 表示設定で非表示にした列はコピー・出力の対象外とする。
+ * 未指定の項目は表示中として扱う。
+ */
+export interface SummaryColumnVisibility {
+  /** 基準工数（月別集計表のみ） */
+  showBaseline?: boolean;
+  /** 予定工数 */
+  showPlanned?: boolean;
+  /** 実績工数 */
+  showActual?: boolean;
+  /** 見通し工数（月別集計表のみ） */
+  showForecast?: boolean;
+  /** 差分（工程別・担当者別集計表のみ） */
+  showDifference?: boolean;
+}
+
+type ResolvedColumnVisibility = Required<SummaryColumnVisibility>;
+
+const DEFAULT_COLUMN_VISIBILITY: ResolvedColumnVisibility = {
+  showBaseline: true,
+  showPlanned: true,
+  showActual: true,
+  showForecast: true,
+  showDifference: true,
+};
+
+function resolveColumnVisibility(
+  columns?: SummaryColumnVisibility
+): ResolvedColumnVisibility {
+  return { ...DEFAULT_COLUMN_VISIBILITY, ...columns };
+}
+
+/** コピー・出力時の工数の小数点桁数 */
+export const OUTPUT_HOURS_FRACTION_DIGITS = 3;
+
+/**
+ * 工数をコピー・出力用にフォーマットする（小数点第3位まで）
+ * @param hours 工数（時間）
+ * @param unit 単位
+ */
+export function formatOutputHours(hours: number, unit: HoursUnit): string {
+  const formatted = convertHours(hours, unit).toFixed(OUTPUT_HOURS_FRACTION_DIGITS);
+  // -0.000 のような表記を避ける
+  return Number(formatted) === 0 ? (0).toFixed(OUTPUT_HOURS_FRACTION_DIGITS) : formatted;
+}
+
+/**
  * クリップボードにコピー
  * navigator.clipboard.writeText()はHTTPS環境でのみ利用可能なため、
  * HTTP環境でも動作するdocument.execCommand('copy')を使用する。
@@ -70,7 +118,7 @@ export function exportTableData(
   const content = [headerRow, ...dataRows].join('\n');
 
   // BOM付きのBlobを作成
-  const bom = '\uFEFF';
+  const bom = '﻿';
   const blob = new Blob([bom + content], { type: 'text/plain;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   // ダウンロードリンクを作成
@@ -86,6 +134,42 @@ export function exportTableData(
   URL.revokeObjectURL(url);
 }
 
+/** 工程別・担当者別集計表の1行分のデータ */
+interface CategorySummaryRow {
+  label: string;
+  taskCount: number;
+  plannedHours: number;
+  actualHours: number;
+  difference: number;
+}
+
+/**
+ * 工程別・担当者別集計表のヘッダーと行を、表示中の列のみで組み立てる
+ */
+function buildCategorySummaryTable(
+  firstColumnHeader: string,
+  rows: CategorySummaryRow[],
+  unit: HoursUnit,
+  columns: ResolvedColumnVisibility
+): { headers: string[]; rows: string[][] } {
+  const unitSuffix = getUnitSuffix(unit);
+
+  const headers = [firstColumnHeader, 'タスク数'];
+  if (columns.showPlanned) headers.push(`予定工数(${unitSuffix})`);
+  if (columns.showActual) headers.push(`実績工数(${unitSuffix})`);
+  if (columns.showDifference) headers.push('差分');
+
+  const dataRows = rows.map(row => {
+    const cells: string[] = [row.label, String(row.taskCount)];
+    if (columns.showPlanned) cells.push(formatOutputHours(row.plannedHours, unit));
+    if (columns.showActual) cells.push(formatOutputHours(row.actualHours, unit));
+    if (columns.showDifference) cells.push(formatOutputHours(row.difference, unit));
+    return cells;
+  });
+
+  return { headers, rows: dataRows };
+}
+
 interface PhaseSummaryData {
   phase: string;
   taskCount: number;
@@ -94,37 +178,38 @@ interface PhaseSummaryData {
   difference: number;
 }
 
+function toPhaseSummaryRows(
+  data: PhaseSummaryData[],
+  total: Omit<PhaseSummaryData, 'phase'>
+): CategorySummaryRow[] {
+  return [
+    ...data.map(item => ({ ...item, label: item.phase })),
+    { ...total, label: '合計' },
+  ];
+}
+
 /**
  * 工程別集計表をクリップボードにコピー
- * @param data 
- * @param total 
- * @param unit 
+ * @param data データ
+ * @param total 合計
+ * @param unit 単位
+ * @param columns 表示中の列
  */
 export async function copyPhaseSummaryToClipboard(
   data: PhaseSummaryData[],
   total: Omit<PhaseSummaryData, 'phase'>,
-  unit: HoursUnit = 'hours'
+  unit: HoursUnit = 'hours',
+  columns?: SummaryColumnVisibility
 ): Promise<void> {
-  const unitSuffix = getUnitSuffix(unit);
-  const headers = ['工程', 'タスク数', `予定工数(${unitSuffix})`, `実績工数(${unitSuffix})`, '差分'];
-  // データを作成
-  const rows = [
-    ...data.map(item => [
-      item.phase,
-      item.taskCount,
-      convertHours(item.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
-      convertHours(item.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
-      convertHours(item.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-    ]),
-    ['合計', total.taskCount,
-      convertHours(total.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
-      convertHours(total.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
-      convertHours(total.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-    ]
-  ];
+  const table = buildCategorySummaryTable(
+    '工程',
+    toPhaseSummaryRows(data, total),
+    unit,
+    resolveColumnVisibility(columns)
+  );
 
   // クリップボードにコピー
-  await copyToClipboard(headers, rows);
+  await copyToClipboard(table.headers, table.rows);
 }
 
 /**
@@ -133,27 +218,23 @@ export async function copyPhaseSummaryToClipboard(
  * @param total 合計
  * @param format フォーマット
  * @param unit 単位
+ * @param columns 表示中の列
  */
 export function exportPhaseSummary(
   data: PhaseSummaryData[],
   total: Omit<PhaseSummaryData, 'phase'>,
   format: 'csv' | 'tsv',
-  unit: HoursUnit = 'hours'
+  unit: HoursUnit = 'hours',
+  columns?: SummaryColumnVisibility
 ): void {
-  const unitSuffix = getUnitSuffix(unit);
-  const headers = ['工程', 'タスク数', `予定工数(${unitSuffix})`, `実績工数(${unitSuffix})`, '差分'];
-  const rows = [
-    ...data.map(item => [
-      item.phase,
-      item.taskCount,
-      convertHours(item.plannedHours, unit),
-      convertHours(item.actualHours, unit),
-      convertHours(item.difference, unit)
-    ]),
-    ['合計', total.taskCount, convertHours(total.plannedHours, unit), convertHours(total.actualHours, unit), convertHours(total.difference, unit)]
-  ];
+  const table = buildCategorySummaryTable(
+    '工程',
+    toPhaseSummaryRows(data, total),
+    unit,
+    resolveColumnVisibility(columns)
+  );
 
-  exportTableData(headers, rows, {
+  exportTableData(table.headers, table.rows, {
     filename: `工程別集計表_${new Date().toISOString().slice(0, 10)}`,
     format
   });
@@ -167,35 +248,37 @@ interface AssigneeSummaryData {
   difference: number;
 }
 
+function toAssigneeSummaryRows(
+  data: AssigneeSummaryData[],
+  total: Omit<AssigneeSummaryData, 'assignee'>
+): CategorySummaryRow[] {
+  return [
+    ...data.map(item => ({ ...item, label: item.assignee })),
+    { ...total, label: '合計' },
+  ];
+}
+
 /**
  * 担当者別集計表をクリップボードにコピー
- * @param data 
- * @param total 
- * @param unit 
+ * @param data データ
+ * @param total 合計
+ * @param unit 単位
+ * @param columns 表示中の列
  */
 export async function copyAssigneeSummaryToClipboard(
   data: AssigneeSummaryData[],
   total: Omit<AssigneeSummaryData, 'assignee'>,
-  unit: HoursUnit = 'hours'
+  unit: HoursUnit = 'hours',
+  columns?: SummaryColumnVisibility
 ): Promise<void> {
-  const unitSuffix = getUnitSuffix(unit);
-  const headers = ['担当者', 'タスク数', `予定工数(${unitSuffix})`, `実績工数(${unitSuffix})`, '差分'];
-  const rows = [
-    ...data.map(item => [
-      item.assignee,
-      item.taskCount,
-      convertHours(item.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
-      convertHours(item.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
-      convertHours(item.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-    ]),
-    ['合計', total.taskCount,
-      convertHours(total.plannedHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
-      convertHours(total.actualHours, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
-      convertHours(total.difference, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-    ]
-  ];
+  const table = buildCategorySummaryTable(
+    '担当者',
+    toAssigneeSummaryRows(data, total),
+    unit,
+    resolveColumnVisibility(columns)
+  );
 
-  await copyToClipboard(headers, rows);
+  await copyToClipboard(table.headers, table.rows);
 }
 
 /**
@@ -204,30 +287,101 @@ export async function copyAssigneeSummaryToClipboard(
  * @param total 合計
  * @param format フォーマット
  * @param unit 単位
+ * @param columns 表示中の列
  */
 export function exportAssigneeSummary(
   data: AssigneeSummaryData[],
   total: Omit<AssigneeSummaryData, 'assignee'>,
   format: 'csv' | 'tsv',
-  unit: HoursUnit = 'hours'
+  unit: HoursUnit = 'hours',
+  columns?: SummaryColumnVisibility
 ): void {
-  const unitSuffix = getUnitSuffix(unit);
-  const headers = ['担当者', 'タスク数', `予定工数(${unitSuffix})`, `実績工数(${unitSuffix})`, '差分'];
-  const rows = [
-    ...data.map(item => [
-      item.assignee,
-      item.taskCount,
-      convertHours(item.plannedHours, unit),
-      convertHours(item.actualHours, unit),
-      convertHours(item.difference, unit)
-    ]),
-    ['合計', total.taskCount, convertHours(total.plannedHours, unit), convertHours(total.actualHours, unit), convertHours(total.difference, unit)]
-  ];
+  const table = buildCategorySummaryTable(
+    '担当者',
+    toAssigneeSummaryRows(data, total),
+    unit,
+    resolveColumnVisibility(columns)
+  );
 
-  exportTableData(headers, rows, {
+  exportTableData(table.headers, table.rows, {
     filename: `担当者別集計表_${new Date().toISOString().slice(0, 10)}`,
     format
   });
+}
+
+/** 月別集計表の工数セル */
+interface MonthlyHoursCell {
+  plannedHours?: number;
+  actualHours?: number;
+  baselineHours?: number;
+  forecastHours?: number;
+}
+
+/** 月別集計表の工数列（表示中のもののみ） */
+function buildMonthlyHoursColumns(
+  unit: HoursUnit,
+  columns: ResolvedColumnVisibility
+): { label: string; pick: (cell?: MonthlyHoursCell) => number }[] {
+  const unitSuffix = getUnitSuffix(unit);
+  const hoursColumns: { label: string; pick: (cell?: MonthlyHoursCell) => number }[] = [];
+
+  if (columns.showBaseline) {
+    hoursColumns.push({ label: `基準(${unitSuffix})`, pick: cell => cell?.baselineHours || 0 });
+  }
+  if (columns.showPlanned) {
+    hoursColumns.push({ label: `予定(${unitSuffix})`, pick: cell => cell?.plannedHours || 0 });
+  }
+  if (columns.showActual) {
+    hoursColumns.push({ label: `実績(${unitSuffix})`, pick: cell => cell?.actualHours || 0 });
+  }
+  if (columns.showForecast) {
+    hoursColumns.push({ label: `見通し(${unitSuffix})`, pick: cell => cell?.forecastHours || 0 });
+  }
+
+  return hoursColumns;
+}
+
+/**
+ * 月別集計表のヘッダーと行を、表示中の列のみで組み立てる
+ */
+function buildMonthlyTable(
+  firstColumnHeader: string,
+  months: string[],
+  rowItems: {
+    label: string;
+    getCell: (month: string) => MonthlyHoursCell | undefined;
+    total: MonthlyHoursCell | undefined;
+  }[],
+  getMonthlyTotal: (month: string) => MonthlyHoursCell | undefined,
+  grandTotal: MonthlyHoursCell,
+  unit: HoursUnit,
+  columns: ResolvedColumnVisibility
+): { headers: string[]; rows: string[][] } {
+  const hoursColumns = buildMonthlyHoursColumns(unit, columns);
+
+  const headers = [
+    firstColumnHeader,
+    ...months.flatMap(month => hoursColumns.map(c => `${month}_${c.label}`)),
+    ...hoursColumns.map(c => `合計_${c.label}`),
+  ];
+
+  const toCells = (cell: MonthlyHoursCell | undefined) =>
+    hoursColumns.map(c => formatOutputHours(c.pick(cell), unit));
+
+  const rows = [
+    ...rowItems.map(item => [
+      item.label,
+      ...months.flatMap(month => toCells(item.getCell(month))),
+      ...toCells(item.total),
+    ]),
+    [
+      '合計',
+      ...months.flatMap(month => toCells(getMonthlyTotal(month))),
+      ...toCells(grandTotal),
+    ],
+  ];
+
+  return { headers, rows };
 }
 
 interface MonthlyAssigneeData {
@@ -265,75 +419,41 @@ interface MonthlyAssigneeData {
   };
 }
 
+function buildMonthlyAssigneeTable(
+  data: MonthlyAssigneeData,
+  unit: HoursUnit,
+  columns: SummaryColumnVisibility | undefined
+): { headers: string[]; rows: string[][] } {
+  return buildMonthlyTable(
+    '担当者',
+    data.months,
+    data.assignees.map(assignee => ({
+      label: assignee,
+      getCell: (month: string) =>
+        data.data.find(d => d.month === month && d.assignee === assignee),
+      total: data.assigneeTotals[assignee],
+    })),
+    (month: string) => data.monthlyTotals[month],
+    data.grandTotal,
+    unit,
+    resolveColumnVisibility(columns)
+  );
+}
+
 /**
  * 月別担当者別集計表をクリップボードにコピー
- * @param data 
- * @param unit 
+ * @param data データ
+ * @param unit 単位
+ * @param columns 表示中の列
  */
 export async function copyMonthlyAssigneeSummaryToClipboard(
   data: MonthlyAssigneeData,
-  unit: HoursUnit = 'hours'
+  unit: HoursUnit = 'hours',
+  columns?: SummaryColumnVisibility
 ): Promise<void> {
-  const unitSuffix = getUnitSuffix(unit);
-  const fmt = (v: number) =>
-    convertHours(v, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-  const headers = [
-    '担当者',
-    ...data.months.flatMap(month => [
-      `${month}_基準(${unitSuffix})`,
-      `${month}_予定(${unitSuffix})`,
-      `${month}_実績(${unitSuffix})`,
-      `${month}_見通し(${unitSuffix})`,
-    ]),
-    `合計_基準(${unitSuffix})`,
-    `合計_予定(${unitSuffix})`,
-    `合計_実績(${unitSuffix})`,
-    `合計_見通し(${unitSuffix})`,
-  ];
+  const table = buildMonthlyAssigneeTable(data, unit, columns);
 
-  const rows = [
-    ...data.assignees.map(assignee => {
-      const row: (string | number)[] = [assignee];
-
-      data.months.forEach(month => {
-        const monthData = data.data.find(d => d.month === month && d.assignee === assignee);
-        row.push(
-          fmt(monthData?.baselineHours || 0),
-          fmt(monthData?.plannedHours || 0),
-          fmt(monthData?.actualHours || 0),
-          fmt(monthData?.forecastHours || 0)
-        );
-      });
-
-      const assigneeTotal = data.assigneeTotals[assignee];
-      row.push(
-        fmt(assigneeTotal?.baselineHours || 0),
-        fmt(assigneeTotal?.plannedHours || 0),
-        fmt(assigneeTotal?.actualHours || 0),
-        fmt(assigneeTotal?.forecastHours || 0)
-      );
-
-      return row;
-    }),
-    [
-      '合計',
-      ...data.months.flatMap(month => {
-        const total = data.monthlyTotals[month];
-        return [
-          fmt(total?.baselineHours || 0),
-          fmt(total?.plannedHours || 0),
-          fmt(total?.actualHours || 0),
-          fmt(total?.forecastHours || 0),
-        ];
-      }),
-      fmt(data.grandTotal.baselineHours || 0),
-      fmt(data.grandTotal.plannedHours),
-      fmt(data.grandTotal.actualHours),
-      fmt(data.grandTotal.forecastHours || 0),
-    ]
-  ];
-
-  await copyToClipboard(headers, rows);
+  await copyToClipboard(table.headers, table.rows);
 }
 
 /**
@@ -341,70 +461,17 @@ export async function copyMonthlyAssigneeSummaryToClipboard(
  * @param data データ
  * @param format フォーマット
  * @param unit 単位
+ * @param columns 表示中の列
  */
 export function exportMonthlyAssigneeSummary(
   data: MonthlyAssigneeData,
   format: 'csv' | 'tsv',
-  unit: HoursUnit = 'hours'
+  unit: HoursUnit = 'hours',
+  columns?: SummaryColumnVisibility
 ): void {
-  const unitSuffix = getUnitSuffix(unit);
-  const headers = [
-    '担当者',
-    ...data.months.flatMap(month => [
-      `${month}_基準(${unitSuffix})`,
-      `${month}_予定(${unitSuffix})`,
-      `${month}_実績(${unitSuffix})`,
-      `${month}_見通し(${unitSuffix})`,
-    ]),
-    `合計_基準(${unitSuffix})`,
-    `合計_予定(${unitSuffix})`,
-    `合計_実績(${unitSuffix})`,
-    `合計_見通し(${unitSuffix})`,
-  ];
+  const table = buildMonthlyAssigneeTable(data, unit, columns);
 
-  const rows = [
-    ...data.assignees.map(assignee => {
-      const row: (string | number)[] = [assignee];
-
-      data.months.forEach(month => {
-        const monthData = data.data.find(d => d.month === month && d.assignee === assignee);
-        row.push(
-          convertHours(monthData?.baselineHours || 0, unit),
-          convertHours(monthData?.plannedHours || 0, unit),
-          convertHours(monthData?.actualHours || 0, unit),
-          convertHours(monthData?.forecastHours || 0, unit)
-        );
-      });
-
-      const assigneeTotal = data.assigneeTotals[assignee];
-      row.push(
-        convertHours(assigneeTotal?.baselineHours || 0, unit),
-        convertHours(assigneeTotal?.plannedHours || 0, unit),
-        convertHours(assigneeTotal?.actualHours || 0, unit),
-        convertHours(assigneeTotal?.forecastHours || 0, unit)
-      );
-
-      return row;
-    }),
-    [
-      '合計',
-      ...data.months.flatMap(month => {
-        const total = data.monthlyTotals[month];
-        return [
-          convertHours(total?.baselineHours || 0, unit),
-          convertHours(total?.plannedHours || 0, unit),
-          convertHours(total?.actualHours || 0, unit),
-          convertHours(total?.forecastHours || 0, unit),
-        ];
-      }),
-      convertHours(data.grandTotal.baselineHours || 0, unit),
-      convertHours(data.grandTotal.plannedHours, unit),
-      convertHours(data.grandTotal.actualHours, unit),
-      convertHours(data.grandTotal.forecastHours || 0, unit)
-    ]
-  ];
-
-  exportTableData(headers, rows, {
+  exportTableData(table.headers, table.rows, {
     filename: `月別担当者別集計表_${new Date().toISOString().slice(0, 10)}`,
     format
   });
@@ -441,72 +508,40 @@ function getCellFromContainer(
   return (container as Record<string, MonthlyPhaseDataCell>)[key];
 }
 
+function buildMonthlyPhaseTable(
+  data: MonthlyPhaseSummaryExportInput,
+  unit: HoursUnit,
+  columns: SummaryColumnVisibility | undefined
+): { headers: string[]; rows: string[][] } {
+  return buildMonthlyTable(
+    '工程',
+    data.months,
+    data.phases.map(phase => ({
+      label: phase,
+      getCell: (month: string) => getCellFromContainer(data.cells, `${month}|${phase}`),
+      total: data.phaseTotals[phase],
+    })),
+    (month: string) => data.monthlyTotals[month],
+    data.grandTotal,
+    unit,
+    resolveColumnVisibility(columns)
+  );
+}
+
 /**
  * 月別工程別集計表をクリップボードにコピー
  * @param data データ
  * @param unit 単位
+ * @param columns 表示中の列
  */
 export async function copyMonthlyPhaseSummaryToClipboard(
   data: MonthlyPhaseSummaryExportInput,
-  unit: HoursUnit = 'hours'
+  unit: HoursUnit = 'hours',
+  columns?: SummaryColumnVisibility
 ): Promise<void> {
-  const unitSuffix = getUnitSuffix(unit);
-  const fmt = (v: number) =>
-    convertHours(v, unit).toLocaleString('ja-JP', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-  const headers = [
-    '工程',
-    ...data.months.flatMap(month => [
-      `${month}_基準(${unitSuffix})`,
-      `${month}_予定(${unitSuffix})`,
-      `${month}_実績(${unitSuffix})`,
-      `${month}_見通し(${unitSuffix})`,
-    ]),
-    `合計_基準(${unitSuffix})`,
-    `合計_予定(${unitSuffix})`,
-    `合計_実績(${unitSuffix})`,
-    `合計_見通し(${unitSuffix})`,
-  ];
+  const table = buildMonthlyPhaseTable(data, unit, columns);
 
-  const rows = [
-    ...data.phases.map(phase => {
-      const row: (string | number)[] = [phase];
-      data.months.forEach(month => {
-        const cell = getCellFromContainer(data.cells, `${month}|${phase}`);
-        row.push(
-          fmt(cell?.baselineHours || 0),
-          fmt(cell?.plannedHours || 0),
-          fmt(cell?.actualHours || 0),
-          fmt(cell?.forecastHours || 0)
-        );
-      });
-      const total = data.phaseTotals[phase];
-      row.push(
-        fmt(total?.baselineHours || 0),
-        fmt(total?.plannedHours || 0),
-        fmt(total?.actualHours || 0),
-        fmt(total?.forecastHours || 0)
-      );
-      return row;
-    }),
-    [
-      '合計',
-      ...data.months.flatMap(month => {
-        const total = data.monthlyTotals[month];
-        return [
-          fmt(total?.baselineHours || 0),
-          fmt(total?.plannedHours || 0),
-          fmt(total?.actualHours || 0),
-          fmt(total?.forecastHours || 0),
-        ];
-      }),
-      fmt(data.grandTotal.baselineHours || 0),
-      fmt(data.grandTotal.plannedHours),
-      fmt(data.grandTotal.actualHours),
-      fmt(data.grandTotal.forecastHours || 0)
-    ]
-  ];
-
-  await copyToClipboard(headers, rows);
+  await copyToClipboard(table.headers, table.rows);
 }
 
 /**
@@ -514,67 +549,17 @@ export async function copyMonthlyPhaseSummaryToClipboard(
  * @param data データ
  * @param format フォーマット
  * @param unit 単位
+ * @param columns 表示中の列
  */
 export function exportMonthlyPhaseSummary(
   data: MonthlyPhaseSummaryExportInput,
   format: 'csv' | 'tsv',
-  unit: HoursUnit = 'hours'
+  unit: HoursUnit = 'hours',
+  columns?: SummaryColumnVisibility
 ): void {
-  const unitSuffix = getUnitSuffix(unit);
-  const headers = [
-    '工程',
-    ...data.months.flatMap(month => [
-      `${month}_基準(${unitSuffix})`,
-      `${month}_予定(${unitSuffix})`,
-      `${month}_実績(${unitSuffix})`,
-      `${month}_見通し(${unitSuffix})`,
-    ]),
-    `合計_基準(${unitSuffix})`,
-    `合計_予定(${unitSuffix})`,
-    `合計_実績(${unitSuffix})`,
-    `合計_見通し(${unitSuffix})`,
-  ];
+  const table = buildMonthlyPhaseTable(data, unit, columns);
 
-  const rows = [
-    ...data.phases.map(phase => {
-      const row: (string | number)[] = [phase];
-      data.months.forEach(month => {
-        const cell = getCellFromContainer(data.cells, `${month}|${phase}`);
-        row.push(
-          convertHours(cell?.baselineHours || 0, unit),
-          convertHours(cell?.plannedHours || 0, unit),
-          convertHours(cell?.actualHours || 0, unit),
-          convertHours(cell?.forecastHours || 0, unit)
-        );
-      });
-      const total = data.phaseTotals[phase];
-      row.push(
-        convertHours(total?.baselineHours || 0, unit),
-        convertHours(total?.plannedHours || 0, unit),
-        convertHours(total?.actualHours || 0, unit),
-        convertHours(total?.forecastHours || 0, unit)
-      );
-      return row;
-    }),
-    [
-      '合計',
-      ...data.months.flatMap(month => {
-        const total = data.monthlyTotals[month];
-        return [
-          convertHours(total?.baselineHours || 0, unit),
-          convertHours(total?.plannedHours || 0, unit),
-          convertHours(total?.actualHours || 0, unit),
-          convertHours(total?.forecastHours || 0, unit),
-        ];
-      }),
-      convertHours(data.grandTotal.baselineHours || 0, unit),
-      convertHours(data.grandTotal.plannedHours, unit),
-      convertHours(data.grandTotal.actualHours, unit),
-      convertHours(data.grandTotal.forecastHours || 0, unit)
-    ]
-  ];
-
-  exportTableData(headers, rows, {
+  exportTableData(table.headers, table.rows, {
     filename: `月別工程別集計表_${new Date().toISOString().slice(0, 10)}`,
     format
   });

--- a/src/utils/summary-column-visibility.ts
+++ b/src/utils/summary-column-visibility.ts
@@ -1,0 +1,73 @@
+/**
+ * 集計表の工数列（基準・予定・実績・見通）の表示制御。
+ *
+ * 実績列は常に表示されるため、基準・予定・見通の3列を同時に表示すると
+ * 4列すべてが表示されることになる。これを避けるため、
+ * 基準・予定・見通のうち同時に表示できるのは最大2列までとする。
+ */
+
+/** 表示切替が可能な工数列 */
+export type ToggleableSummaryColumn = 'baseline' | 'planned' | 'forecast';
+
+/** 表示切替が可能な工数列の表示状態 */
+export interface SummaryColumnSettings {
+  showBaseline: boolean;
+  showPlanned: boolean;
+  showForecast: boolean;
+}
+
+const SETTING_KEYS: Record<ToggleableSummaryColumn, keyof SummaryColumnSettings> = {
+  baseline: 'showBaseline',
+  planned: 'showPlanned',
+  forecast: 'showForecast',
+};
+
+/** 同時に表示できる列数（実績列は常に表示されるため、残りは2列まで） */
+const MAX_VISIBLE_TOGGLEABLE_COLUMNS = 2;
+
+/**
+ * 指定した列を表示に切り替えられるか
+ * @param settings 現在の表示状態
+ * @param column 対象の列
+ */
+export function canEnableSummaryColumn(
+  settings: SummaryColumnSettings,
+  column: ToggleableSummaryColumn
+): boolean {
+  const otherVisibleCount = (
+    Object.keys(SETTING_KEYS) as ToggleableSummaryColumn[]
+  ).filter((c) => c !== column && settings[SETTING_KEYS[c]]).length;
+
+  return otherVisibleCount < MAX_VISIBLE_TOGGLEABLE_COLUMNS;
+}
+
+/**
+ * 指定した列の表示状態を切り替える。
+ * 4列すべてが表示される切り替えは無視し、現在の状態をそのまま返す。
+ * @param settings 現在の表示状態
+ * @param column 対象の列
+ * @param next 切り替え後の表示状態
+ */
+export function toggleSummaryColumn(
+  settings: SummaryColumnSettings,
+  column: ToggleableSummaryColumn,
+  next: boolean
+): SummaryColumnSettings {
+  if (next && !canEnableSummaryColumn(settings, column)) {
+    return settings;
+  }
+  return { ...settings, [SETTING_KEYS[column]]: next };
+}
+
+/**
+ * 表示切替を操作できないか（非表示かつ表示にできない列）
+ * @param settings 現在の表示状態
+ * @param column 対象の列
+ */
+export function isSummaryColumnToggleDisabled(
+  settings: SummaryColumnSettings,
+  column: ToggleableSummaryColumn
+): boolean {
+  if (settings[SETTING_KEYS[column]]) return false;
+  return !canEnableSummaryColumn(settings, column);
+}


### PR DESCRIPTION
## Summary

This PR adds column visibility controls to summary tables (phase, assignee, and monthly summaries), allowing users to toggle the display of specific columns while respecting constraints that prevent all four work-hour columns (baseline, planned, actual, forecast) from being displayed simultaneously.

## Key Changes

- **New column visibility system** (`src/utils/summary-column-visibility.ts`):
  - Implements logic to ensure baseline/planned/forecast columns can display at most 2 simultaneously (actual is always shown)
  - Provides `toggleSummaryColumn()`, `canEnableSummaryColumn()`, and `isSummaryColumnToggleDisabled()` utilities
  - Includes comprehensive unit tests validating the constraint enforcement

- **Enhanced export/copy functions** (`src/utils/export-table.ts`):
  - Added `SummaryColumnVisibility` interface to control which columns are exported
  - Introduced `formatOutputHours()` function that formats hours to 3 decimal places (replacing inconsistent 2-decimal formatting)
  - Refactored category summary functions (`copyPhaseSummaryToClipboard`, `copyAssigneeSummaryToClipboard`, `exportPhaseSummary`, `exportAssigneeSummary`) to use new `buildCategorySummaryTable()` helper
  - Refactored monthly summary functions to use new `buildMonthlyTable()` helper
  - Fixed BOM character encoding in CSV/TSV exports
  - All export functions now accept optional `columns` parameter to control output

- **New UI component** (`src/components/wbs/summary-display-settings.tsx`):
  - Reusable `SummaryDisplaySettings` dropdown component for toggling column visibility
  - Displays disabled state for columns that cannot be enabled due to constraints
  - Shows explanatory message when constraint is active

- **Updated summary table components**:
  - `wbs-summary-tables.tsx`: Integrated column visibility controls for phase and assignee summaries with constraint enforcement
  - `monthly-assignee-summary.tsx`: Replaced custom settings UI with `SummaryDisplaySettings` component
  - `monthly-phase-summary.tsx`: Replaced custom settings UI with `SummaryDisplaySettings` component
  - `monthly-summary-table.tsx`: Added `showPlanned` prop to support column visibility toggling

- **Comprehensive test coverage** (`src/__tests__/`):
  - Added `export-table.test.ts` validating export functions respect column visibility and format hours correctly
  - Added `summary-column-visibility.test.ts` validating constraint logic
  - Added `monthly-summary-table-columns.test.tsx` validating table rendering with different column configurations

## Implementation Details

- The constraint system prevents 4 columns from displaying simultaneously by limiting baseline/planned/forecast to 2 visible columns maximum (actual is always shown)
- Export functions now consistently format hours to 3 decimal places using `formatOutputHours()`, replacing the previous inconsistent 2-decimal formatting in clipboard operations
- Column visibility state is passed through export function parameters, allowing UI to control what gets copied/exported independently of what's displayed
- The `SummaryDisplaySettings` component is reusable across different summary table types with configurable columns and constraint handling

https://claude.ai/code/session_0111TnYV9BioCruGuyoQSHZT